### PR TITLE
Removed overheads from runtime checking when they can be compiled away.

### DIFF
--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -81,4 +81,4 @@ from .term import (
 )
 
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/diffrax/global_interpolation.py
+++ b/diffrax/global_interpolation.py
@@ -16,7 +16,8 @@ class AbstractGlobalInterpolation(AbstractPath):
     ts: Array["times"]  # noqa: F821
 
     def __post_init__(self):
-        error_if(self.ts.ndim != 1, "`ts` must be one dimensional.")
+        if self.ts.ndim != 1:
+            raise ValueError("`ts` must be one dimensional.")
 
     def _ts_size(self):
         return self.ts.shape[0]
@@ -64,11 +65,11 @@ class LinearInterpolation(AbstractGlobalInterpolation):
 
     def __post_init__(self):
         def _check(_ys):
-            error_if(
-                _ys.shape[0] != self.ts.shape[0],
-                "Must have ts.shape[0] == ys.shape[0], that is to say the same number "
-                "of entries along the timelike dimension.",
-            )
+            if _ys.shape[0] != self.ts.shape[0]:
+                raise ValueError(
+                    "Must have ts.shape[0] == ys.shape[0], that is to say the same "
+                    "number of entries along the timelike dimension."
+                )
 
         jax.tree_map(_check, self.ys)
 
@@ -180,10 +181,14 @@ class CubicInterpolation(AbstractGlobalInterpolation):
                 "Each cubic coefficient must have `times - 1` entries, where "
                 "`times = self.ts.shape[0]`."
             )
-            error_if(d.shape[0] + 1 != self.ts.shape[0], error_msg)
-            error_if(c.shape[0] + 1 != self.ts.shape[0], error_msg)
-            error_if(b.shape[0] + 1 != self.ts.shape[0], error_msg)
-            error_if(a.shape[0] + 1 != self.ts.shape[0], error_msg)
+            if d.shape[0] + 1 != self.ts.shape[0]:
+                raise ValueError(error_msg)
+            if c.shape[0] + 1 != self.ts.shape[0]:
+                raise ValueError(error_msg)
+            if b.shape[0] + 1 != self.ts.shape[0]:
+                raise ValueError(error_msg)
+            if a.shape[0] + 1 != self.ts.shape[0]:
+                raise ValueError(error_msg)
 
         jax.tree_map(_check, *self.coeffs)
 
@@ -336,8 +341,10 @@ class DenseInterpolation(AbstractGlobalInterpolation):
 
 
 def _check_ts(ts: Array["times"]) -> None:  # noqa: F821
-    error_if(ts.ndim != 1, f"`ts` must be 1-dimensional; got {ts.ndim}.")
-    error_if(ts.shape[0] < 2, f"`ts` must be of length at least 2; got {ts.shape[0]}")
+    if ts.ndim != 1:
+        raise ValueError(f"`ts` must be 1-dimensional; got {ts.ndim}.")
+    if ts.shape[0] < 2:
+        raise ValueError(f"`ts` must be of length at least 2; got {ts.shape[0]}")
     # Also catches any NaN times.
     error_if(ts[:-1] >= ts[1:], "`ts` must be monotonically strictly increasing.")
 

--- a/diffrax/integrate.py
+++ b/diffrax/integrate.py
@@ -600,12 +600,12 @@ def diffeqsolve(
     # Error checking
     if dt0 is not None:
         msg = (
-            "Must have (t1 - t0) * dt0 > 0, we instead got: "
-            f"t1, with value: {t1} and type {type(t1)}, "
-            f"t0, with value: {t0} and type {type(t0)} and, "
-            f"dt0, with value: {dt0} and type {type(dt0)}"
+            "Must have (t1 - t0) * dt0 >= 0, we instead got "
+            f"t1 with value {t1} and type {type(t1)}, "
+            f"t0 with value {t0} and type {type(t0)}, "
+            f"dt0 with value {dt0} and type {type(dt0)}"
         )
-        error_if(lambda: (t1 - t0) * dt0 <= 0, msg)
+        error_if(lambda: (t1 - t0) * dt0 < 0, msg)
 
     # Error checking
     term_leaves, term_structure = jax.tree_flatten(
@@ -748,10 +748,10 @@ def diffeqsolve(
         # We have no way of knowing how many steps we'll actually end up taking, and
         # XLA doesn't support dynamic shapes. So we just have to allocate the maximum
         # amount of steps we can possibly take.
-        error_if(
-            max_steps is None,
-            "`max_steps=None` is incompatible with `saveat.steps=True`",
-        )
+        if max_steps is None:
+            raise ValueError(
+                "`max_steps=None` is incompatible with `saveat.steps=True`"
+            )
         out_size += max_steps
     if saveat.t1 and not saveat.steps:
         out_size += 1
@@ -766,10 +766,10 @@ def diffeqsolve(
     result = jnp.array(RESULTS.successful)
     if saveat.dense:
         error_if(t0 == t1, "Cannot save dense output if t0 == t1")
-        error_if(
-            max_steps is None,
-            "`max_steps=None` is incompatible with `saveat.dense=True`",
-        )
+        if max_steps is None:
+            raise ValueError(
+                "`max_steps=None` is incompatible with `saveat.dense=True`"
+            )
         (
             _,
             _,

--- a/diffrax/integrate.py
+++ b/diffrax/integrate.py
@@ -605,7 +605,7 @@ def diffeqsolve(
             f"t0 with value {t0} and type {type(t0)}, "
             f"dt0 with value {dt0} and type {type(dt0)}"
         )
-        error_if(lambda: (t1 - t0) * dt0 < 0, msg)
+        error_if((t1 - t0) * dt0 < 0, msg)
 
     # Error checking
     term_leaves, term_structure = jax.tree_flatten(

--- a/diffrax/misc/errors.py
+++ b/diffrax/misc/errors.py
@@ -35,4 +35,4 @@ def branched_error_if(
         raise error_cls(msgs[_index.item()])
 
     pred = unvmap_any(pred)
-    lax.cond(pred, lambda: hcb.call(raises, (index,)), lambda: None)
+    lax.cond(pred, lambda: hcb.call(raises, index), lambda: None)

--- a/diffrax/misc/errors.py
+++ b/diffrax/misc/errors.py
@@ -1,19 +1,14 @@
-from typing import Callable, Sequence, Type, Union
+from typing import Sequence, Type, Union
 
-import jax
 import jax.experimental.host_callback as hcb
-import jax.numpy as jnp
-import numpy as np
+import jax.lax as lax
 
 from ..custom_types import Array, Int
 from .unvmap import unvmap_any
 
 
-_Bool = Union[bool, Array[..., bool]]
-
-
 def error_if(
-    pred: Union[_Bool, Callable[[], _Bool]],
+    pred: Union[bool, Array[..., bool]],
     msg: str,
     error_cls: Type[Exception] = ValueError,
 ) -> bool:
@@ -31,34 +26,13 @@ def error_if(
 
 
 def branched_error_if(
-    pred: Union[_Bool, Callable[[], _Bool]],
+    pred: Union[bool, Array[..., bool]],
     index: Int,
     msgs: Sequence[str],
     error_cls: Type[Exception] = ValueError,
 ) -> bool:
-    def raises(_arg):
-        _pred, _index = _arg
-        if _pred:
-            if isinstance(_index, jnp.ndarray):
-                _index = _index.item()
-            raise error_cls(msgs[_index])
+    def raises(_index):
+        raise error_cls(msgs[_index.item()])
 
-    if callable(pred):
-        with jax.ensure_compile_time_eval():
-            pred = pred()
-
-    if isinstance(pred, jnp.ndarray):
-        with jax.ensure_compile_time_eval():
-            pred = unvmap_any(pred)
-
-    if isinstance(pred, jax.core.Tracer):
-        hcb.call(raises, (pred, index))
-    elif isinstance(pred, (bool, np.ndarray, jnp.ndarray)):
-        raises((pred, index))
-    else:
-        msg = (
-            "`pred` must either be a `bool`, a JAX array, or a zero-argument callable "
-            "that returns a `bool` or JAX array, instead we got "
-            f"value: {pred} of type: {type(pred)}."
-        )
-        assert False, msg
+    pred = unvmap_any(pred)
+    lax.cond(pred, lambda: hcb.call(raises, (index,)), lambda: None)

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -57,7 +57,7 @@ def test_vmap_y0(stepsize_controller):
     assert jnp.array_equal(sol.ts, jnp.full((10, 1), t1))
     assert sol.ys.shape == (10, 1, 2)
 
-    _t = [0, 0.3, 0.7, 1]
+    _t = jnp.array([0, 0.3, 0.7, 1])
     saveat = diffrax.SaveAt(ts=_t)
     sol = jax.vmap(
         lambda y0i: diffrax.diffeqsolve(


### PR DESCRIPTION
Closes #76.

When doing `error_if(cond, ...)` or `branched_error_if(cond, ...)` with `cond` a tracer, then the truthy/falsey-ness of this tracer was previously established at the Python level, by passing it as an argument to a normal Python `if` statement as part of a `jax.experimental.host_callback.call`. This means hitting the Python interpreter a lot.

Now we instead use a `lax.cond` around the `host_callback.call` instead. This means that if this tracer can be determine to be falsey by the XLA compiler, it will compile away the whole check, or at the very least not hit the Python interpreter.

In particular we were hitting this on the check [here](https://github.com/patrick-kidger/diffrax/blob/d5090fe46a079dc1bbe3e3aeabee88d0d21acacb/diffrax/integrate.py#L879), despite `result == RESULTS.successful` being something that is known at compile time.

---

In addition, this PR swaps out a lot of `error_if` statements for normal `if` statements. I don't think this should really matter from a performance point of view, but it seems worth avoiding the extra machinery of `error_if` if possible.