### PR TITLE
Adjusted PIDController

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _From a technical point of view, the internal structure of the library is pretty
 pip install diffrax
 ```
 
-Requires Python >=3.7 and JAX >=0.2.27.
+Requires Python >=3.7 and JAX >=0.3.4.
 
 ## Documentation
 

--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -81,4 +81,4 @@ from .term import (
 )
 
 
-__version__ = "0.0.6"
+__version__ = "0.1.0"

--- a/diffrax/misc/__init__.py
+++ b/diffrax/misc/__init__.py
@@ -10,7 +10,7 @@ from .misc import (
     linear_rescale,
     rms_norm,
 )
-from .nextafter import nextafter, nextbefore
+from .nextafter import nextafter, prevbefore
 from .omega import ω
 from .sde_kl_divergence import sde_kl_divergence
 from .unvmap import unvmap_all, unvmap_any, unvmap_max

--- a/diffrax/misc/nextafter.py
+++ b/diffrax/misc/nextafter.py
@@ -19,9 +19,9 @@ nextafter.defjvps(lambda x_dot, _, __: x_dot)
 
 
 @jax.custom_jvp
-def nextbefore(x: Array) -> Array:
+def prevbefore(x: Array) -> Array:
     y = jnp.nextafter(x, jnp.NINF)
     return jnp.where(x == 0, -jnp.finfo(x.dtype).tiny, y)
 
 
-nextbefore.defjvps(lambda x_dot, _, __: x_dot)
+prevbefore.defjvps(lambda x_dot, _, __: x_dot)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ _From a technical point of view, the internal structure of the library is pretty
 pip install diffrax
 ```
 
-Requires Python >=3.7 and JAX >=0.2.27.
+Requires Python >=3.7 and JAX >=0.3.4.
 
 ## Quick example
 

--- a/examples/neural_cde.ipynb
+++ b/examples/neural_cde.ipynb
@@ -161,7 +161,7 @@
     "            ts[-1],\n",
     "            dt0,\n",
     "            y0,\n",
-    "            stepsize_controller=diffrax.PIDController(),\n",
+    "            stepsize_controller=diffrax.PIDController(rtol=1e-3, atol=1e-6),\n",
     "            saveat=saveat,\n",
     "        )\n",
     "        if evolving_out:\n",

--- a/examples/neural_ode.ipynb
+++ b/examples/neural_ode.ipynb
@@ -112,7 +112,7 @@
     "            t1=ts[-1],\n",
     "            dt0=ts[1] - ts[0],\n",
     "            y0=y0,\n",
-    "            stepsize_controller=diffrax.PIDController(),\n",
+    "            stepsize_controller=diffrax.PIDController(rtol=1e-3, atol=1e-6),\n",
     "            saveat=diffrax.SaveAt(ts=ts),\n",
     "        )\n",
     "        return solution.ys"

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ classifiers = [
 python_requires = "~=3.7"
 
 install_requires = [
-    "jax>=0.2.27",
-    "jaxlib>=0.1.76",
+    "jax>=0.3.4",
+    "jaxlib>=0.3.0",
     "equinox>=0.1.6",
 ]
 

--- a/test/test_adaptive_stepsize_controller.py
+++ b/test/test_adaptive_stepsize_controller.py
@@ -1,0 +1,67 @@
+import diffrax
+import jax.numpy as jnp
+
+
+def test_step_ts():
+    term = diffrax.ODETerm(lambda t, y, args: -0.2 * y)
+    solver = diffrax.Dopri5()
+    t0 = 0
+    t1 = 5
+    dt0 = None
+    y0 = 1.0
+    stepsize_controller = diffrax.PIDController(rtol=1e-4, atol=1e-6, step_ts=[3, 4])
+    saveat = diffrax.SaveAt(steps=True)
+    sol = diffrax.diffeqsolve(
+        term,
+        solver,
+        t0,
+        t1,
+        dt0,
+        y0,
+        stepsize_controller=stepsize_controller,
+        saveat=saveat,
+    )
+    assert 3 in sol.ts
+    assert 4 in sol.ts
+
+
+def test_jump_ts():
+    # Tests no regression of https://github.com/patrick-kidger/diffrax/issues/58
+
+    def vector_field(t, y, args):
+        x, v = y
+        force = jnp.where(t < 7.5, 10, -10)
+        return v, -4 * jnp.pi**2 * x - 4 * jnp.pi * 0.05 * v + force
+
+    term = diffrax.ODETerm(vector_field)
+    solver = diffrax.Dopri5()
+    t0 = 0
+    t1 = 15
+    dt0 = None
+    y0 = 1.5, 0
+    saveat = diffrax.SaveAt(steps=True)
+
+    def run(**kwargs):
+        stepsize_controller = diffrax.PIDController(rtol=1e-4, atol=1e-6, **kwargs)
+        return diffrax.diffeqsolve(
+            term,
+            solver,
+            t0,
+            t1,
+            dt0,
+            y0,
+            stepsize_controller=stepsize_controller,
+            saveat=saveat,
+        )
+
+    sol_no_jump_ts = run()
+    sol_with_jump_ts = run(jump_ts=[7.5])
+    assert sol_no_jump_ts.stats["num_steps"] > sol_with_jump_ts.stats["num_steps"]
+    assert sol_with_jump_ts.result == 0
+
+    sol = run(jump_ts=[7.5], step_ts=[7.5])
+    assert sol.result == 0
+    sol = run(jump_ts=[7.5], step_ts=[3.5, 8])
+    assert sol.result == 0
+    assert 3.5 in sol.ts
+    assert 8 in sol.ts

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -123,7 +123,9 @@ def test_adjoint_seminorm():
 
     def solve(y0):
         adjoint = diffrax.BacksolveAdjoint(
-            stepsize_controller=diffrax.PIDController(norm=diffrax.adjoint_rms_seminorm)
+            stepsize_controller=diffrax.PIDController(
+                rtol=1e-3, atol=1e-6, norm=diffrax.adjoint_rms_seminorm
+            )
         )
         sol = diffrax.diffeqsolve(
             term,

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -132,7 +132,7 @@ def test_adjoint_seminorm():
             1,
             None,
             y0,
-            stepsize_controller=diffrax.PIDController(),
+            stepsize_controller=diffrax.PIDController(rtol=1e-3, atol=1e-6),
             adjoint=adjoint,
         )
         return jnp.sum(sol.ys)

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -46,7 +46,10 @@ def _all_pairs(*args):
         ),
         dict(default=jnp.float32, opts=(int, float, jnp.int32)),
         dict(default=treedefs[0], opts=treedefs[1:]),
-        dict(default=diffrax.ConstantStepSize(), opts=(diffrax.PIDController(),)),
+        dict(
+            default=diffrax.ConstantStepSize(),
+            opts=(diffrax.PIDController(rtol=1e-3, atol=1e-6),),
+        ),
     ),
 )
 def test_basic(solver_ctr, t_dtype, treedef, stepsize_controller, getkey):
@@ -249,7 +252,9 @@ def test_reverse_time(solver_ctr, dt0, saveat, getkey):
     key = getkey()
     y0 = jrandom.normal(key, (2, 2))
     stepsize_controller = (
-        diffrax.PIDController() if dt0 is None else diffrax.ConstantStepSize()
+        diffrax.PIDController(rtol=1e-3, atol=1e-6)
+        if dt0 is None
+        else diffrax.ConstantStepSize()
     )
 
     def f(t, y, args):
@@ -326,12 +331,24 @@ def test_compile_time_steps():
     solver = diffrax.Tsit5()
 
     sol = diffrax.diffeqsolve(
-        terms, solver, 0, 1, None, y0, stepsize_controller=diffrax.PIDController()
+        terms,
+        solver,
+        0,
+        1,
+        None,
+        y0,
+        stepsize_controller=diffrax.PIDController(rtol=1e-3, atol=1e-6),
     )
     assert sol.stats["compiled_num_steps"] is None
 
     sol = diffrax.diffeqsolve(
-        terms, solver, 0, 1, 0.1, y0, stepsize_controller=diffrax.PIDController()
+        terms,
+        solver,
+        0,
+        1,
+        0.1,
+        y0,
+        stepsize_controller=diffrax.PIDController(rtol=1e-3, atol=1e-6),
     )
     assert sol.stats["compiled_num_steps"] is None
 

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -8,7 +8,7 @@ def test_half_solver():
     y0 = 1.0
     dt0 = None
     solver = diffrax.HalfSolver(diffrax.Euler())
-    stepsize_controller = diffrax.PIDController(rtl=1e-3, atol=1e-6)
+    stepsize_controller = diffrax.PIDController(rtol=1e-3, atol=1e-6)
     diffrax.diffeqsolve(
         term, solver, t0, t1, dt0, y0, stepsize_controller=stepsize_controller
     )

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -8,7 +8,7 @@ def test_half_solver():
     y0 = 1.0
     dt0 = None
     solver = diffrax.HalfSolver(diffrax.Euler())
-    stepsize_controller = diffrax.PIDController()
+    stepsize_controller = diffrax.PIDController(rtl=1e-3, atol=1e-6)
     diffrax.diffeqsolve(
         term, solver, t0, t1, dt0, y0, stepsize_controller=stepsize_controller
     )

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -6,7 +6,8 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "stepsize_controller", (diffrax.ConstantStepSize(), diffrax.PIDController())
+    "stepsize_controller",
+    (diffrax.ConstantStepSize(), diffrax.PIDController(rtol=1e-3, atol=1e-6)),
 )
 def test_vmap_y0(stepsize_controller):
     t0 = 0


### PR DESCRIPTION
Closes #58.
This turned out to be a few subtle errors in the way that jumps were handled in `PIDController`. Should now be fixed.

Closes #73.
This has now been upstreamed into main JAX, so the monkey-patch is superfluous here. This has additionally raised the mininum JAX version required.

Closes #84.
This is the reason for incrementing to a new minor (breaking) version: relative and absolute tolerances for `PIDController` must now always be specified; no more default. This should help force people to think about what tolerances they're using, which is a common source of errors with new users. To help out, the documentation also now has a small discussion about how to choose solver tolerances.