### PR TITLE
Bump version

### DIFF
--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -81,4 +81,4 @@ from .term import (
 )
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
Bumps the version to create a new release, due to #91. Doing a new release now as those changes are necessary to keep Diffrax compatible with the next JAX release.