### PR TITLE
switch error_if to python if (regarding google/jax/issues/10047)

### DIFF
--- a/diffrax/nonlinear_solver/newton.py
+++ b/diffrax/nonlinear_solver/newton.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 import jax.scipy as jsp
 
 from ..custom_types import Bool, Int, PyTree, Scalar
-from ..misc import error_if, rms_norm
+from ..misc import rms_norm
 from ..solution import RESULTS
 from .base import AbstractNonlinearSolver, LU_Jacobian, NonlinearSolution
 
@@ -81,8 +81,8 @@ class NewtonNonlinearSolver(AbstractNonlinearSolver):
     tolerate_nonconvergence: bool = False
 
     def __post_init__(self):
-        if self.max_steps is not None:
-            error_if(self.max_steps < 2, "max_steps must be at least 2.")
+        if self.max_steps is not None and self.max_steps < 2:
+            raise ValueError("max_steps must be at least 2.")
 
     def _solve(
         self,


### PR DESCRIPTION
Hey @patrick-kidger,

This is causing some failures in the internal tests and switching the if statement fixes them. Does this make sense, or did you have other intentions to keep this `error_if`?
This issue is relavant to[ your recent changes](https://github.com/patrick-kidger/diffrax/commit/23a1c199ac5e50d86a500cddd612b3b06ab45c50)  and also [google/jax/issues/10047](https://github.com/google/jax/issues/10047).

Thank you