### PR TITLE
Clarify in docs that StepTo checks correctness of `ts`.

### DIFF
--- a/diffrax/step_size_controller/constant.py
+++ b/diffrax/step_size_controller/constant.py
@@ -148,6 +148,8 @@ class StepTo(AbstractStepSizeController):
 StepTo.__init__.__doc__ = """**Arguments:**
 
 - `ts`: The times to step to. Must be an increasing/decreasing sequence of times
-    between the `t0` and `t1` passed to [`diffrax.diffeqsolve`][].
+    between the `t0` and `t1` (inclusive) passed to [`diffrax.diffeqsolve`][].
+    Correctness of `ts` with respect to `t0` and `t1` as well as its
+    monotonicity is checked by the implementation.
 - `compile_steps`: As [`diffrax.ConstantStepSize.__init__`][].
 """


### PR DESCRIPTION
Adds the answer to #120 in `StepTo` docstring. The JAX ecosystem is full of silent errors so I think it's useful to tell the user explicitly they don't need to be paranoid about misusing the feature (like I was).