### PR TITLE
Added events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
             python-version: "3.8"
             test-script: |
-                python -m pip install pytest psutil jax jaxlib equinox scipy
+                python -m pip install pytest psutil jax jaxlib equinox scipy optax
                 cp -r ${{ github.workspace }}/test ./test
                 pytest
             pypi-token: ${{ secrets.pypi_token }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest psutil wheel scipy numpy jaxlib
+          python -m pip install pytest psutil wheel scipy numpy optax jaxlib
 
       - name: Checks with pre-commit
         uses: pre-commit/action@v2.0.3

--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -1,10 +1,16 @@
 from .adjoint import (
     AbstractAdjoint,
     BacksolveAdjoint,
+    ImplicitAdjoint,
     NoAdjoint,
     RecursiveCheckpointAdjoint,
 )
 from .brownian import AbstractBrownianPath, UnsafeBrownianPath, VirtualBrownianTree
+from .event import (
+    AbstractDiscreteTerminatingEvent,
+    DiscreteTerminatingEvent,
+    SteadyStateEvent,
+)
 from .global_interpolation import (
     AbstractGlobalInterpolation,
     backward_hermite_coefficients,
@@ -81,4 +87,4 @@ from .term import (
 )
 
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/diffrax/adjoint.py
+++ b/diffrax/adjoint.py
@@ -125,7 +125,7 @@ class ImplicitAdjoint(AbstractAdjoint):
             _t = _state_no_y.tprev
             (_y,) = _ys  # unpack length-1 dimension
             _args, _terms = _args__terms
-            return solver.vf(_terms, _t, _y, _args)
+            return solver.func(_terms, _t, _y, _args)
 
         def _solve(_args__terms):
             _args, _terms = _args__terms

--- a/diffrax/adjoint.py
+++ b/diffrax/adjoint.py
@@ -6,7 +6,7 @@ import jax
 import jax.lax as lax
 import jax.numpy as jnp
 
-from .misc import nondifferentiable_output, ω
+from .misc import implicit_jvp, nondifferentiable_output, ω
 from .saveat import SaveAt
 from .term import AbstractTerm, AdjointTerm
 
@@ -22,6 +22,7 @@ class AbstractAdjoint(eqx.Module):
         terms,
         solver,
         stepsize_controller,
+        discrete_terminating_event,
         saveat,
         t0,
         t1,
@@ -92,6 +93,69 @@ class NoAdjoint(AbstractAdjoint):
         return final_state, aux_stats
 
 
+class ImplicitAdjoint(AbstractAdjoint):
+    r"""Backpropagate via the [implicit function theorem](https://en.wikipedia.org/wiki/Implicit_function_theorem#Statement_of_the_theorem).
+
+    This is used when solving towards a steady state, typically using
+    [`diffrax.SteadyStateEvent`][]. In this case, the output of the solver is $y(θ)$
+    for which $f(t, y(θ), θ) = 0$. (Where $θ$ corresponds to all parameters found
+    through `terms` and `args`, but not `y0`.) Then we can skip backpropagating through
+    the solver and instead directly compute
+    $\frac{\mathrm{d}y}{\mathrm{d}θ} = - (\frac{\mathrm{d}f}{\mathrm{d}y})^{-1}\frac{\mathrm{d}f}{\mathrm{d}θ}$
+    via the implicit function theorem.
+    """  # noqa: E501
+
+    def loop(self, *, args, terms, solver, saveat, throw, init_state, **kwargs):
+        del throw
+
+        # `is` check because this may return a Tracer from SaveAt(ts=<array>)
+        if eqx.tree_equal(saveat, SaveAt(t1=True)) is not True:
+            raise ValueError(
+                "Can only use `adjoint=ImplicitAdjoint()` with `SaveAt(t1=True)`."
+            )
+
+        init_state = eqx.tree_at(
+            lambda s: (s.y, s.solver_state, s.controller_state),
+            init_state,
+            replace_fn=lax.stop_gradient,
+        )
+
+        def _vf(_ys, _residual, _args__terms):
+            _state_no_y, _ = _residual
+            _t = _state_no_y.tprev
+            (_y,) = _ys  # unpack length-1 dimension
+            _args, _terms = _args__terms
+            return solver.vf(_terms, _t, _y, _args)
+
+        def _solve(_args__terms):
+            _args, _terms = _args__terms
+            _final_state, _aux_stats = self._loop_fn(
+                **kwargs,
+                args=_args,
+                terms=_terms,
+                solver=solver,
+                saveat=saveat,
+                init_state=init_state,
+                is_bounded=False,
+            )
+            # Note that we use .ys not .y here. The former is what is actually returned
+            # by diffeqsolve, so it is the thing we want to attach the tangent to.
+            return _final_state.ys, (
+                eqx.tree_at(lambda s: s.ys, _final_state, None),
+                _aux_stats,
+            )
+
+        ys, residual = implicit_jvp(_solve, _vf, (args, terms))
+
+        final_state_no_ys, aux_stats = residual
+        return (
+            eqx.tree_at(
+                lambda s: s.ys, final_state_no_ys, ys, is_leaf=lambda x: x is None
+            ),
+            aux_stats,
+        )
+
+
 # Compute derivatives with respect to the first argument:
 # - y, corresponding to the initial state;
 # - args, corresponding to explicit parameters;
@@ -116,7 +180,6 @@ def _loop_backsolve_fwd(y__args__terms, **kwargs):
     return (final_state, aux_stats), (ts, ys)
 
 
-# TODO: implement this as a single diffeqsolve with events, once events are supported.
 def _loop_backsolve_bwd(
     residuals,
     grad_final_state__aux_stats,
@@ -125,6 +188,7 @@ def _loop_backsolve_bwd(
     self,
     solver,
     stepsize_controller,
+    discrete_terminating_event,
     saveat,
     t0,
     t1,
@@ -162,6 +226,7 @@ def _loop_backsolve_bwd(
         adjoint=self,
         solver=solver,
         stepsize_controller=stepsize_controller,
+        discrete_terminating_event=discrete_terminating_event,
         terms=adjoint_terms,
         dt0=None if dt0 is None else -dt0,
         max_steps=max_steps,

--- a/diffrax/event.py
+++ b/diffrax/event.py
@@ -81,7 +81,9 @@ class SteadyStateEvent(AbstractDiscreteTerminatingEvent):
                 "manually."
             )
 
-        vf = solver.vf(terms, state.tprev, state.y, args)
+        # TODO: this makes an additional function evaluation that in practice has
+        # probably already been made by the solver.
+        vf = solver.func(terms, state.tprev, state.y, args)
         return self.norm(vf) < _atol + _rtol * self.norm(state.y)
 
 

--- a/diffrax/event.py
+++ b/diffrax/event.py
@@ -1,0 +1,96 @@
+import abc
+from typing import Callable, Optional
+
+import equinox as eqx
+
+from .custom_types import Bool, PyTree, Scalar
+from .misc import rms_norm
+from .step_size_controller import AbstractAdaptiveStepSizeController
+
+
+class AbstractDiscreteTerminatingEvent(eqx.Module):
+    """Evaluated at the end of each integration step. If true then the solve is stopped
+    at that time.
+    """
+
+    @abc.abstractmethod
+    def __call__(self, state, **kwargs):
+        """**Arguments:**
+
+        - `state`: a dataclass of the evolving state of the system, including in
+            particular the solution `state.y` at time `state.tprev`.
+        - `**kwargs`: the integration options held constant throughout the solve
+            are passed as keyword arguments: `terms`, `solver`, `args`. etc.
+
+        **Returns**
+
+        A boolean. If true then the solve is terminated.
+        """
+
+
+class DiscreteTerminatingEvent(AbstractDiscreteTerminatingEvent):
+    """Terminates the solve if its condition is ever active."""
+
+    cond_fn: Callable[..., Bool]
+
+    def __call__(self, state, **kwargs):
+        return self.cond_fn(state, **kwargs)
+
+
+DiscreteTerminatingEvent.__init__.__doc__ = """**Arguments:**
+
+- `cond_fn`: A function `(state, **kwargs) -> bool` that is evaluated on every step of
+    the differential equation solve. If it returns `True` then the solve is finished at
+    that timestep. `state` is a dataclass of the evolving state of the system,
+    including in particular the solution `state.y` at time `state.tprev`. Passed as
+    keyword arguments are the `terms`, `solver`, `args` etc. that are constant
+    throughout the solve.
+"""
+
+
+class SteadyStateEvent(AbstractDiscreteTerminatingEvent):
+    """Terminates the solve once it reaches a steady state."""
+
+    rtol: Optional[float] = None
+    atol: Optional[float] = None
+    norm: Callable[[PyTree], Scalar] = rms_norm
+
+    def __call__(self, state, *, terms, args, solver, stepsize_controller, **kwargs):
+        del kwargs
+        _error = False
+        if self.rtol is None:
+            if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
+                _rtol = stepsize_controller.rtol
+            else:
+                _error = True
+        else:
+            _rtol = self.rtol
+        if self.atol is None:
+            if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
+                _atol = stepsize_controller.atol
+            else:
+                _error = True
+        else:
+            _atol = self.atol
+        if _error:
+            raise ValueError(
+                "The `rtol` and `atol` tolerances for `SteadyStateEvent` default "
+                "to the `rtol` and `atol` used with an adaptive step size "
+                "controller (such as `diffrax.PIDController`). Either use an "
+                "adaptive step size controller, or specify these tolerances "
+                "manually."
+            )
+
+        vf = solver.vf(terms, state.tprev, state.y, args)
+        return self.norm(vf) < _atol + _rtol * self.norm(state.y)
+
+
+SteadyStateEvent.__init__.__doc__ = """**Arguments:**
+
+- `rtol`: The relative tolerance for determining convergence. Defaults to the
+    same `rtol` as passed to an adaptive step controller if one is used.
+- `atol`: The absolute tolerance for determining convergence. Defaults to the
+    same `atol` as passed to an adaptive step controller if one is used.
+- `norm`: A function `PyTree -> Scalar`, which is called to determine whether
+    the vector field is close to zero.
+"""

--- a/diffrax/integrate.py
+++ b/diffrax/integrate.py
@@ -743,12 +743,12 @@ def diffeqsolve(
     error_order = solver.error_order(terms)
     if controller_state is None:
         (tnext, controller_state) = stepsize_controller.init(
-            terms, t0, t1, y0, dt0, args, solver.func_for_init, error_order
+            terms, t0, t1, y0, dt0, args, solver.func, error_order
         )
     else:
         if dt0 is None:
             (tnext, _) = stepsize_controller.init(
-                terms, t0, t1, y0, dt0, args, solver.func_for_init, error_order
+                terms, t0, t1, y0, dt0, args, solver.func, error_order
             )
         else:
             tnext = t0 + dt0

--- a/diffrax/misc/__init__.py
+++ b/diffrax/misc/__init__.py
@@ -1,4 +1,9 @@
-from .ad import fixed_custom_jvp, nondifferentiable_input, nondifferentiable_output
+from .ad import (
+    fixed_custom_jvp,
+    implicit_jvp,
+    nondifferentiable_input,
+    nondifferentiable_output,
+)
 from .bounded_while_loop import bounded_while_loop, HadInplaceUpdate
 from .errors import branched_error_if, error_if
 from .misc import (

--- a/diffrax/misc/ad.py
+++ b/diffrax/misc/ad.py
@@ -1,12 +1,15 @@
+import functools as ft
 from typing import Any
 
 import equinox as eqx
 import jax
+import jax.flatten_util as fu
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
 import jax.interpreters.xla as xla
 import jax.lax as lax
+import jax.numpy as jnp
 
 from ..custom_types import PyTree
 
@@ -109,3 +112,66 @@ class fixed_custom_jvp:
         )
         nondiff_args_tracer = jax.tree_map(lax.stop_gradient, nondiff_args_tracer)
         return self.fn(nondiff_args_nontracer, nondiff_args_tracer, diff_args)
+
+
+# TODO: I think the jacfwd and the jvp can probably be combined, as they both
+# basically do the same thing. That might improve efficiency via parallelism.
+def implicit_jvp(fn_primal, fn_rewrite, args):
+    """
+    Takes a function `fn_primal : args -> (root, residual)` and a function
+    `fn_rewrite : (root, residual, args) -> arb`.
+
+    Has primals `fn_primal(args)[0]` with auxiliary information `fn_primal(args)[1]`.
+    Has tangents `-(dfn_rewrite/droot)^-1 dfn_rewrite/dargs`, evaluated at
+    `(root, residual, args)`.
+
+    This is used for rewriting gradients via the implicit function theorem.
+    """
+    diff_args, nondiff_args = eqx.partition(args, eqx.is_inexact_array)
+    root, residual = _implicit_backprop(fn_primal, fn_rewrite, nondiff_args, diff_args)
+    # Trim off the zero tangents we added to `residual`.
+    return root, jax.tree_map(lax.stop_gradient, residual)
+
+
+@ft.partial(fixed_custom_jvp, nondiff_argnums=(0, 1, 2))
+def _implicit_backprop(fn_primal, fn_rewrite, nondiff_args, diff_args):
+    del fn_rewrite
+    args = eqx.combine(diff_args, nondiff_args)
+    return fn_primal(args)
+
+
+@_implicit_backprop.defjvp
+def _implicit_backprop_jvp(
+    fn_primal, fn_rewrite, nondiff_args, diff_args, tang_diff_args
+):
+    (diff_args,) = diff_args
+    (tang_diff_args,) = tang_diff_args
+    root, residual = _implicit_backprop(fn_primal, fn_rewrite, nondiff_args, diff_args)
+
+    flat_root, unflatten_root = fu.ravel_pytree(root)
+    args = eqx.combine(nondiff_args, diff_args)
+
+    def _for_jac(_root):
+        _root = unflatten_root(_root)
+        _out = fn_rewrite(_root, residual, args)
+        _out, _ = fu.ravel_pytree(_out)
+        return _out
+
+    jac_flat_root = jax.jacfwd(_for_jac)(flat_root)
+
+    flat_diff_args, unflatten_diff_args = fu.ravel_pytree(diff_args)
+    flat_tang_diff_args, _ = fu.ravel_pytree(tang_diff_args)
+
+    def _for_jvp(_diff_args):
+        _diff_args = unflatten_diff_args(_diff_args)
+        _args = eqx.combine(nondiff_args, _diff_args)
+        _out = fn_rewrite(root, residual, _args)
+        _out, _ = fu.ravel_pytree(_out)
+        return _out
+
+    _, jvp_flat_diff_args = jax.jvp(_for_jvp, (flat_diff_args,), (flat_tang_diff_args,))
+
+    tang_root = -jnp.linalg.solve(jac_flat_root, jvp_flat_diff_args)
+    tang_root = unflatten_root(tang_root)
+    tang_residual = jax.tree_map(jnp.zeros_like, residual)
+    return (root, residual), (tang_root, tang_residual)

--- a/diffrax/nonlinear_solver/base.py
+++ b/diffrax/nonlinear_solver/base.py
@@ -4,11 +4,12 @@ from typing import Callable, Optional, Tuple, TypeVar
 import equinox as eqx
 import jax
 import jax.flatten_util as fu
+import jax.lax as lax
 import jax.numpy as jnp
 import jax.scipy as jsp
 
 from ..custom_types import Int, PyTree, Scalar
-from ..misc import fixed_custom_jvp
+from ..misc import implicit_jvp
 from ..solution import RESULTS
 
 
@@ -29,13 +30,6 @@ class AbstractNonlinearSolver(eqx.Module):
 
     rtol: Optional[Scalar] = None
     atol: Optional[Scalar] = None
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        # Note that this breaks the descriptor protocol so we have to pass self
-        # manually in __call__.
-        cls._solve = fixed_custom_jvp(cls._solve, nondiff_argnums=(0, 1, 2, 3, 4))
-        cls._solve.defjvp(_root_solve_jvp)
 
     @abc.abstractmethod
     def _solve(
@@ -80,10 +74,21 @@ class AbstractNonlinearSolver(eqx.Module):
         whether the solver managed to converge or not.
         """
 
-        # TODO: switch from is_inexact_array to is_perturbed once JAX issue #9567 is
-        # fixed.
+        x = lax.stop_gradient(x)
         diff_args, nondiff_args = eqx.partition(args, eqx.is_inexact_array)
-        return self._solve(self, fn, x, jac, nondiff_args, diff_args)
+
+        def _primal(_diff_args):
+            nsol = self._solve(fn, x, jac, nondiff_args, _diff_args)
+            return nsol.root, eqx.tree_at(lambda s: s.root, nsol, None)
+
+        def _rewrite(_root, _, _diff_args):
+            _args = eqx.combine(_diff_args, nondiff_args)
+            return fn(_root, _args)
+
+        root, nsol_no_root = implicit_jvp(_primal, _rewrite, diff_args)
+        return eqx.tree_at(
+            lambda s: s.root, nsol_no_root, root, is_leaf=lambda z: z is None
+        )
 
     @staticmethod
     def jac(fn: Callable, x: PyTree, args: PyTree) -> LU_Jacobian:
@@ -98,65 +103,3 @@ class AbstractNonlinearSolver(eqx.Module):
             # Handle integer arguments
             flat = flat.astype(jnp.float32)
         return jsp.linalg.lu_factor(jax.jacfwd(curried)(flat))
-
-
-# TODO: I think the jacfwd and the jvp can probably be combined, as they both
-# basically do the same thing. That might improve efficiency via parallelism.
-# TODO: support differentiating wrt `fn`? This isn't terribly hard -- just pass it as
-# part of `diff_args` and use a custom "apply" instead of `fn`. However I can see that
-# stating "differentiating wrt `fn` is allowed" might result in confusion if an attempt
-# is made to differentiate wrt anything `fn` closes over. (Which is the behaviour of
-# `lax.custom_root`. Such closure-differentiation is "magical" behaviour that I won't
-# ever put into code I write; if differentiating wrt "closed over values" is expected
-# then it's much safer to require that `fn` be a PyTree a la Equinox, but at time of
-# writing that isn't yet culturally widespread enough.)
-def _root_solve_jvp(
-    self: AbstractNonlinearSolver,
-    fn: callable,
-    x: PyTree,
-    jac: Optional[LU_Jacobian],
-    nondiff_args: PyTree,
-    diff_args: PyTree,
-    tang_diff_args: PyTree,
-):
-    """JVP for differentiably solving for the root of a function, via the implicit
-    function theorem.
-
-    Gradients are computed with respect to diff_args.
-
-    This is a lot like lax.custom_root -- we just use less magic. Rather than creating
-    gradients for whatever the function happened to close over, we create gradients for
-    just diff_args.
-    """
-
-    (diff_args,) = diff_args
-    (tang_diff_args,) = tang_diff_args
-    solution = self._solve(self, fn, x, jac, nondiff_args, diff_args)
-    root = solution.root
-
-    flat_root, unflatten_root = fu.ravel_pytree(root)
-    args = eqx.combine(nondiff_args, diff_args)
-
-    def _for_jac(_root):
-        _root = unflatten_root(_root)
-        _out = fn(_root, args)
-        _out, _ = fu.ravel_pytree(_out)
-        return _out
-
-    jac_flat_root = jax.jacfwd(_for_jac)(flat_root)
-
-    flat_diff_args, unflatten_diff_args = fu.ravel_pytree(diff_args)
-    flat_tang_diff_args, _ = fu.ravel_pytree(tang_diff_args)
-
-    def _for_jvp(_diff_args):
-        _diff_args = unflatten_diff_args(_diff_args)
-        _args = eqx.combine(nondiff_args, _diff_args)
-        _out = fn(root, _args)
-        _out, _ = fu.ravel_pytree(_out)
-        return _out
-
-    _, jvp_flat_diff_args = jax.jvp(_for_jvp, (flat_diff_args,), (flat_tang_diff_args,))
-
-    tang_root = -jnp.linalg.solve(jac_flat_root, jvp_flat_diff_args)
-    tang_root = unflatten_root(tang_root)
-    return solution, NonlinearSolution(root=tang_root, num_steps=0, result=0)

--- a/diffrax/solution.py
+++ b/diffrax/solution.py
@@ -1,6 +1,8 @@
 from dataclasses import field
 from typing import Any, Dict, Optional
 
+import jax.numpy as jnp
+
 from .custom_types import Array, Bool, PyTree, Scalar
 from .global_interpolation import DenseInterpolation
 from .misc import ContainerMeta
@@ -18,6 +20,38 @@ class RESULTS(metaclass=ContainerMeta):
     implicit_nonconvergence = (
         "Implicit method did not converge within the required number of iterations."
     )
+    discrete_terminating_event_occurred = (
+        "Terminating solve because a discrete event occurred."
+    )
+
+
+def is_okay(result: RESULTS) -> Bool:
+    return is_successful(result) | is_event(result)
+
+
+def is_successful(result: RESULTS) -> Bool:
+    return result == RESULTS.successful
+
+
+# TODO: In the future we may support other event types, in which case this function
+# should be updated.
+def is_event(result: RESULTS) -> Bool:
+    return result == RESULTS.discrete_terminating_event_occurred
+
+
+def update_result(old_result: RESULTS, new_result: RESULTS) -> RESULTS:
+    """
+    Returns:
+
+        old | success event_o error_o
+    new     |
+    --------+-------------------------
+    success | success event_o error_o
+    event_n | event_n event_o error_o
+    error_n | error_n error_n error_o
+    """
+    out_result = jnp.where(is_okay(old_result), new_result, old_result)
+    return jnp.where(is_okay(new_result) & is_event(old_result), old_result, out_result)
 
 
 class Solution(AbstractPath):

--- a/diffrax/solver/base.py
+++ b/diffrax/solver/base.py
@@ -144,30 +144,23 @@ class AbstractSolver(eqx.Module, metaclass=_MetaAbstractSolver):
             happened successfully, or if (unusually) it failed for some reason.
         """
 
-    def func_for_init(
+    @abc.abstractmethod
+    def func(
         self, terms: PyTree[AbstractTerm], t0: Scalar, y0: PyTree, args: PyTree
     ) -> PyTree:
-        """Provides vector field evaluations to select the initial step size.
+        """Evaluate the vector field at a point. (This is unlike
+        [`diffrax.AbstractSolver.step`][], which operates over an interval.)
 
-        This is used to make a point evaluation. This is unlike
-        [`diffrax.AbstractSolver.step`][], which operates over an interval.
-
-        In general differential equation solvers are interval-based. There is precisely
-        one place where point evaluations are needed: selecting the initial step size
-        automatically in an ODE solve. And that is what this function is for.
+        For most operations differential equation solvers are interval-based, so this
+        opertion should be used sparingly. This operation is needed for things like
+        selecting an initial step size.
 
         **Arguments:** As [`diffrax.diffeqsolve`][]
 
         **Returns:**
 
-        The evaluation of the vector field at `t0`.
+        The evaluation of the vector field at `t0`, `y0`.
         """
-
-        raise ValueError(
-            "An initial step size cannot be selected automatically. The most common "
-            "scenario for this error to occur is when trying to use adaptive step "
-            "size solvers with SDEs. Please specify an initial `dt0` instead."
-        )
 
 
 class AbstractImplicitSolver(AbstractSolver):
@@ -306,10 +299,8 @@ class HalfSolver(AbstractAdaptiveSolver, AbstractWrappedSolver):
 
         return y1, y_error, dense_info, solver_state, result
 
-    def func_for_init(
-        self, terms: PyTree[AbstractTerm], t0: Scalar, y0: PyTree, args: PyTree
-    ):
-        return self.solver.func_for_init(terms, t0, y0, args)
+    def func(self, terms: PyTree[AbstractTerm], t0: Scalar, y0: PyTree, args: PyTree):
+        return self.solver.func(terms, t0, y0, args)
 
 
 HalfSolver.__init__.__doc__ = """**Arguments:**

--- a/diffrax/solver/euler.py
+++ b/diffrax/solver/euler.py
@@ -47,11 +47,11 @@ class Euler(AbstractItoSolver):
         dense_info = dict(y0=y0, y1=y1)
         return y1, None, dense_info, None, RESULTS.successful
 
-    def func_for_init(
+    def func(
         self,
         terms: AbstractTerm,
         t0: Scalar,
         y0: PyTree,
         args: PyTree,
     ) -> PyTree:
-        return terms.func_for_init(t0, y0, args)
+        return terms.vf(t0, y0, args)

--- a/diffrax/solver/euler_heun.py
+++ b/diffrax/solver/euler_heun.py
@@ -55,3 +55,13 @@ class EulerHeun(AbstractStratonovichSolver):
 
         dense_info = dict(y0=y0, y1=y1)
         return y1, None, dense_info, None, RESULTS.successful
+
+    def func(
+        self,
+        terms: Tuple[AbstractTerm, AbstractTerm],
+        t0: Scalar,
+        y0: PyTree,
+        args: PyTree,
+    ) -> PyTree:
+        drift, diffusion = terms
+        return drift.vf(t0, y0, args), diffusion.vf(t0, y0, args)

--- a/diffrax/solver/implicit_euler.py
+++ b/diffrax/solver/implicit_euler.py
@@ -56,11 +56,11 @@ class ImplicitEuler(AbstractImplicitSolver):
         dense_info = dict(y0=y0, y1=y1)
         return y1, None, dense_info, None, nonlinear_sol.result
 
-    def func_for_init(
+    def func(
         self,
         terms: AbstractTerm,
         t0: Scalar,
         y0: PyTree,
         args: PyTree,
     ) -> PyTree:
-        return terms.func_for_init(t0, y0, args)
+        return terms.vf(t0, y0, args)

--- a/diffrax/solver/leapfrog_midpoint.py
+++ b/diffrax/solver/leapfrog_midpoint.py
@@ -72,11 +72,11 @@ class LeapfrogMidpoint(AbstractSolver):
         solver_state = (t0, y0)
         return y1, None, dense_info, solver_state, RESULTS.successful
 
-    def func_for_init(
+    def func(
         self,
         terms: AbstractTerm,
         t0: Scalar,
         y0: PyTree,
         args: PyTree,
     ) -> PyTree:
-        return terms.func_for_init(t0, y0, args)
+        return terms.vf(t0, y0, args)

--- a/diffrax/solver/milstein.py
+++ b/diffrax/solver/milstein.py
@@ -71,6 +71,16 @@ class StratonovichMilstein(AbstractStratonovichSolver):
         dense_info = dict(y0=y0, y1=y1)
         return y1, None, dense_info, None, RESULTS.successful
 
+    def func(
+        self,
+        terms: Tuple[AbstractTerm, AbstractTerm],
+        t0: Scalar,
+        y0: PyTree,
+        args: PyTree,
+    ) -> PyTree:
+        drift, diffusion = terms
+        return drift.vf(t0, y0, args), diffusion.vf(t0, y0, args)
+
 
 class ItoMilstein(AbstractItoSolver):
     r"""Milstein's method; Itô version.
@@ -312,3 +322,13 @@ class ItoMilstein(AbstractItoSolver):
 
         dense_info = dict(y0=y0, y1=y1)
         return y1, None, dense_info, None, RESULTS.successful
+
+    def func(
+        self,
+        terms: Tuple[AbstractTerm, AbstractTerm],
+        t0: Scalar,
+        y0: PyTree,
+        args: PyTree,
+    ) -> PyTree:
+        drift, diffusion = terms
+        return drift.vf(t0, y0, args), diffusion.vf(t0, y0, args)

--- a/diffrax/solver/reversible_heun.py
+++ b/diffrax/solver/reversible_heun.py
@@ -75,11 +75,11 @@ class ReversibleHeun(AbstractAdaptiveSolver, AbstractStratonovichSolver):
         solver_state = (yhat1, vf1)
         return y1, y1_error, dense_info, solver_state, RESULTS.successful
 
-    def func_for_init(
+    def func(
         self,
         terms: AbstractTerm,
         t0: Scalar,
         y0: PyTree,
         args: PyTree,
     ) -> PyTree:
-        return terms.func_for_init(t0, y0, args)
+        return terms.vf(t0, y0, args)

--- a/diffrax/solver/runge_kutta.py
+++ b/diffrax/solver/runge_kutta.py
@@ -205,14 +205,14 @@ class AbstractRungeKutta(AbstractAdaptiveSolver):
     def calculate_jacobian(self) -> CalculateJacobian:
         pass
 
-    def func_for_init(
+    def func(
         self,
         terms: AbstractTerm,
         t0: Scalar,
         y0: PyTree,
         args: PyTree,
     ) -> PyTree:
-        return terms.func_for_init(t0, y0, args)
+        return terms.vf(t0, y0, args)
 
     def init(
         self,

--- a/diffrax/solver/runge_kutta.py
+++ b/diffrax/solver/runge_kutta.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ..custom_types import Bool, DenseInfo, PyTree, Scalar
 from ..misc import ContainerMeta, ω
-from ..solution import RESULTS
+from ..solution import is_okay, RESULTS, update_result
 from ..term import AbstractTerm
 from .base import AbstractAdaptiveSolver, AbstractImplicitSolver, vector_tree_dot
 
@@ -607,9 +607,7 @@ class AbstractRungeKutta(AbstractAdaptiveSolver):
                         _ki = _nonlinear_sol.root
                     else:
                         assert False
-                _result = jnp.where(
-                    _result == RESULTS.successful, _nonlinear_sol.result, _result
-                )
+                _result = update_result(_result, _nonlinear_sol.result)
                 del _nonlinear_sol
             else:
                 # Explicit stage
@@ -740,7 +738,7 @@ class AbstractRungeKutta(AbstractAdaptiveSolver):
         else:
             y_error = vector_tree_dot(self.tableau.b_error, ks)
         y_error = jax.tree_map(
-            lambda _y_error: jnp.where(result == RESULTS.successful, _y_error, jnp.inf),
+            lambda _y_error: jnp.where(is_okay(result), _y_error, jnp.inf),
             y_error,
         )  # i.e. an implicit step failed to converge
 

--- a/diffrax/solver/semi_implicit_euler.py
+++ b/diffrax/solver/semi_implicit_euler.py
@@ -50,7 +50,7 @@ class SemiImplicitEuler(AbstractSolver):
         dense_info = dict(y0=y0, y1=y1)
         return y1, None, dense_info, None, RESULTS.successful
 
-    def func_for_init(
+    def func(
         self,
         terms: Tuple[AbstractTerm, AbstractTerm],
         t0: Scalar,
@@ -60,6 +60,6 @@ class SemiImplicitEuler(AbstractSolver):
 
         term_1, term_2 = terms
         y0_1, y0_2 = y0
-        f1 = term_1.func_for_init(t0, y0_2, args)
-        f2 = term_2.func_for_init(t0, y0_1, args)
+        f1 = term_1.func(t0, y0_2, args)
+        f2 = term_2.func(t0, y0_1, args)
         return (f1, f2)

--- a/diffrax/step_size_controller/adaptive.py
+++ b/diffrax/step_size_controller/adaptive.py
@@ -19,13 +19,13 @@ def _select_initial_step(
     t0: Scalar,
     y0: PyTree,
     args: PyTree,
-    func_for_init: Callable[[Scalar, PyTree, PyTree], PyTree],
+    func: Callable[[Scalar, PyTree, PyTree], PyTree],
     error_order: Scalar,
     rtol: Scalar,
     atol: Scalar,
     norm: Callable[[PyTree], Scalar],
 ) -> Scalar:
-    f0 = func_for_init(terms, t0, y0, args)
+    f0 = func(terms, t0, y0, args)
     scale = (atol + ω(y0).call(jnp.abs) * rtol).ω
     d0 = norm((y0**ω / scale**ω).ω)
     d1 = norm((f0**ω / scale**ω).ω)
@@ -36,7 +36,7 @@ def _select_initial_step(
 
     t1 = t0 + h0
     y1 = (y0**ω + h0 * f0**ω).ω
-    f1 = func_for_init(terms, t1, y1, args)
+    f1 = func(terms, t1, y1, args)
     d2 = norm(((f1**ω - f0**ω) / scale**ω).ω) / h0
 
     max_d = jnp.maximum(d1, d2)
@@ -305,7 +305,7 @@ class PIDController(AbstractAdaptiveStepSizeController):
         y0: PyTree,
         dt0: Optional[Scalar],
         args: PyTree,
-        func_for_init: Callable[[Scalar, PyTree, PyTree], PyTree],
+        func: Callable[[Scalar, PyTree, PyTree], PyTree],
         error_order: Optional[Scalar],
     ) -> Tuple[Scalar, _ControllerState]:
         del t1
@@ -316,7 +316,7 @@ class PIDController(AbstractAdaptiveStepSizeController):
                 t0,
                 y0,
                 args,
-                func_for_init,
+                func,
                 error_order,
                 self.rtol,
                 self.atol,

--- a/diffrax/step_size_controller/adaptive.py
+++ b/diffrax/step_size_controller/adaptive.py
@@ -391,14 +391,9 @@ class PIDController(AbstractAdaptiveStepSizeController):
         # `scaled_error = norm(y_error) / (atol + norm(y) * rtol)`  (2)
         # We do (1). torchdiffeq and torchsde do (1). Soderlind's papers and
         # OrdinaryDiffEq.jl do (2).
-        # We choose to do (1) by considering what were to happen if we were to increase
-        # the dimensionality of `y` and `y_error` with zeros. (i.e. append as many
-        # `dy/dt=0` problems as we please, and then solve them perfectly) Assuming that
-        # `norm` normalises by the number of dimensions (e.g. like an RMS norm) then
-        # (2) will see `norm(y_error) -> 0`, `norm(y) -> 0`, and therefore `atol`
-        # playing a larger and larger role. In contrast (2) simply scales things down
-        # without `atol` taking on extra importance. (This is quite thin justification
-        # though.)
+        # We choose to do (1) by considering what if `y` were to contain different
+        # components at very different scales. The errors in the small components may
+        # be drowned out by the errors in the big components if we were using (2).
         #
         # Some will put the multiplication by `safety` outside the `coeff/error_order`
         # exponent. (1) Some will put it inside. (2)

--- a/diffrax/step_size_controller/base.py
+++ b/diffrax/step_size_controller/base.py
@@ -59,7 +59,7 @@ class AbstractStepSizeController(eqx.Module):
         y0: PyTree,
         dt0: Optional[Scalar],
         args: PyTree,
-        func_for_init: Callable[[Scalar, PyTree, PyTree], PyTree],
+        func: Callable[[Scalar, PyTree, PyTree], PyTree],
         error_order: Optional[Scalar],
     ) -> Tuple[Scalar, _ControllerState]:
         r"""Determines the size of the first step, and initialise any hidden state for
@@ -67,7 +67,7 @@ class AbstractStepSizeController(eqx.Module):
 
         **Arguments:** As `diffeqsolve`.
 
-        - `func_for_init`: The value of `solver.func_for_init`.
+        - `func`: The value of `solver.func`.
         - `error_order`: The order of the error estimate. If solving an ODE this will
             typically be `solver.order()`. If solving an SDE this will typically be
             `solver.strong_order() + 0.5`.

--- a/diffrax/step_size_controller/constant.py
+++ b/diffrax/step_size_controller/constant.py
@@ -28,10 +28,10 @@ class ConstantStepSize(AbstractStepSizeController):
         y0: PyTree,
         dt0: Optional[Scalar],
         args: PyTree,
-        func_for_init: Callable[[Scalar, PyTree, PyTree], PyTree],
+        func: Callable[[Scalar, PyTree, PyTree], PyTree],
         error_order: Optional[Scalar],
     ) -> Tuple[Scalar, Scalar]:
-        del terms, t1, y0, args, func_for_init, error_order
+        del terms, t1, y0, args, func, error_order
         if dt0 is None:
             raise ValueError(
                 "Constant step size solvers cannot select step size automatically; "
@@ -108,10 +108,10 @@ class StepTo(AbstractStepSizeController):
         y0: PyTree,
         dt0: None,
         args: PyTree,
-        func_for_init: Callable[[Scalar, PyTree, PyTree], PyTree],
+        func: Callable[[Scalar, PyTree, PyTree], PyTree],
         error_order: Optional[Scalar],
     ) -> Tuple[Scalar, int]:
-        del y0, args, func_for_init, error_order
+        del y0, args, func, error_order
         if dt0 is not None:
             raise ValueError(
                 "`dt0` should be `None`. Step location is already determined "

--- a/docs/api/adjoints.md
+++ b/docs/api/adjoints.md
@@ -31,6 +31,10 @@ There are multiple ways to backpropagate through a differential equation (to com
     selection:
         members: false
 
+::: diffrax.ImplicitAdjoint
+    selection:
+        members: false
+
 ::: diffrax.BacksolveAdjoint
     selection:
         members:

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,0 +1,24 @@
+# Events
+
+Events allow for interrupting a differential equation solve, and changing its internal state, or terminating the solve before `t1` is reached.
+
+At the moment a single kind of event is supported: discrete events which are checked at the end of every step, and which halt the integration once they become true.
+
+??? abstract "`diffrax.AbstractDiscreteTerminatingEvent`"
+
+    ::: diffrax.AbstractDiscreteTerminatingEvent
+        selection:
+            members:
+                - __call__
+
+---
+
+::: diffrax.DiscreteTerminatingEvent
+    selection:
+        members:
+            - __init__
+
+::: diffrax.SteadyStateEvent
+    selection:
+        members:
+            - __init__

--- a/docs/api/solvers/abstract_solvers.md
+++ b/docs/api/solvers/abstract_solvers.md
@@ -18,7 +18,7 @@ In addition [`diffrax.AbstractSolver`][] has several subclasses that you can use
             - error_order
             - init
             - step
-            - func_for_init
+            - func
 
 ---
 

--- a/examples/steady_state.ipynb
+++ b/examples/steady_state.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9877bdcb",
+   "metadata": {},
+   "source": [
+    "# Steady states"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a16df75",
+   "metadata": {},
+   "source": [
+    "This example demonstrates how to use Diffrax to solve an ODE until it reaches a steady state. The key feature will be the use of event handling to detect that the steady state has been reached.\n",
+    "\n",
+    "In addition, for this example we need to backpropagate through the procedure of finding a steady state. We can do this efficiently using the implicit function theorem.\n",
+    "\n",
+    "This example is available as a Jupyter notebook [here](https://github.com/patrick-kidger/diffrax/blob/main/examples/steady_state.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7053a132",
+   "metadata": {
+    "execute": {
+     "shell": {
+      "execute_reply": "2022-07-15T17:49:27.190533+00:00"
+     }
+    },
+    "iopub": {
+     "execute_input": "2022-07-15T17:46:56.174218+00:00",
+     "status": {
+      "busy": "2022-07-15T17:46:56.173283+00:00",
+      "idle": "2022-07-15T17:49:27.191890+00:00"
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import diffrax\n",
+    "import equinox as eqx  # https://github.com/patrick-kidger/equinox\n",
+    "import jax.numpy as jnp\n",
+    "import optax  # https://github.com/deepmind/optax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5a39737f",
+   "metadata": {
+    "execute": {
+     "shell": {
+      "execute_reply": "2022-07-15T17:49:27.200260+00:00"
+     }
+    },
+    "iopub": {
+     "execute_input": "2022-07-15T17:49:27.194682+00:00",
+     "status": {
+      "busy": "2022-07-15T17:49:27.194211+00:00",
+      "idle": "2022-07-15T17:49:27.201694+00:00"
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class ExponentialDecayToSteadyState(eqx.Module):\n",
+    "    steady_state: float\n",
+    "\n",
+    "    def __call__(self, t, y, args):\n",
+    "        return self.steady_state - y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "525b5430",
+   "metadata": {
+    "execute": {
+     "shell": {
+      "execute_reply": "2022-07-15T17:49:27.210168+00:00"
+     }
+    },
+    "iopub": {
+     "execute_input": "2022-07-15T17:49:27.203780+00:00",
+     "status": {
+      "busy": "2022-07-15T17:49:27.202937+00:00",
+      "idle": "2022-07-15T17:49:27.211528+00:00"
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def loss(model, target_steady_state):\n",
+    "    term = diffrax.ODETerm(model)\n",
+    "    solver = diffrax.Tsit5()\n",
+    "    t0 = 0\n",
+    "    t1 = jnp.inf\n",
+    "    dt0 = None\n",
+    "    y0 = 1.0\n",
+    "    max_steps = None\n",
+    "    controller = diffrax.PIDController(rtol=1e-3, atol=1e-6)\n",
+    "    event = diffrax.SteadyStateEvent()\n",
+    "    adjoint = diffrax.ImplicitAdjoint()\n",
+    "    # This combination of event, t1, max_steps, adjoint is particularly\n",
+    "    # natural: we keep integration forever until we hit the event, with\n",
+    "    # no maximum time or number of steps. Backpropagation happens via\n",
+    "    # the implicit function theorem.\n",
+    "    sol = diffrax.diffeqsolve(\n",
+    "        term,\n",
+    "        solver,\n",
+    "        t0,\n",
+    "        t1,\n",
+    "        dt0,\n",
+    "        y0,\n",
+    "        max_steps=max_steps,\n",
+    "        stepsize_controller=controller,\n",
+    "        discrete_terminating_event=event,\n",
+    "        adjoint=adjoint,\n",
+    "    )\n",
+    "    (y1,) = sol.ys\n",
+    "    return (y1 - target_steady_state) ** 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ec634466",
+   "metadata": {
+    "execute": {
+     "shell": {
+      "execute_reply": "2022-07-15T17:49:28.926507+00:00"
+     }
+    },
+    "iopub": {
+     "execute_input": "2022-07-15T17:49:27.214972+00:00",
+     "status": {
+      "busy": "2022-07-15T17:49:27.214240+00:00",
+      "idle": "2022-07-15T17:49:28.927742+00:00"
+     }
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Step: 0 Steady State: 0.025839969515800476\n",
+      "Step: 1 Steady State: 0.058249037712812424\n",
+      "Step: 2 Steady State: 0.09451574087142944\n",
+      "Step: 3 Steady State: 0.13270404934883118\n",
+      "Step: 4 Steady State: 0.17144456505775452\n",
+      "Step: 5 Steady State: 0.2097906768321991\n",
+      "Step: 6 Steady State: 0.24709917604923248\n",
+      "Step: 7 Steady State: 0.28294336795806885\n",
+      "Step: 8 Steady State: 0.3170691728591919\n",
+      "Step: 9 Steady State: 0.34933507442474365\n",
+      "Step: 10 Steady State: 0.37968066334724426\n",
+      "Step: 11 Steady State: 0.4081019163131714\n",
+      "Step: 12 Steady State: 0.43463483452796936\n",
+      "Step: 13 Steady State: 0.45934173464775085\n",
+      "Step: 14 Steady State: 0.4823019802570343\n",
+      "Step: 15 Steady State: 0.5035936236381531\n",
+      "Step: 16 Steady State: 0.5233209133148193\n",
+      "Step: 17 Steady State: 0.5415788888931274\n",
+      "Step: 18 Steady State: 0.5584676265716553\n",
+      "Step: 19 Steady State: 0.5740787982940674\n",
+      "Step: 20 Steady State: 0.5885017514228821\n",
+      "Step: 21 Steady State: 0.6018210053443909\n",
+      "Step: 22 Steady State: 0.6141175627708435\n",
+      "Step: 23 Steady State: 0.6254667043685913\n",
+      "Step: 24 Steady State: 0.6359376907348633\n",
+      "Step: 25 Steady State: 0.6455990076065063\n",
+      "Step: 26 Steady State: 0.6545112729072571\n",
+      "Step: 27 Steady State: 0.6627309322357178\n",
+      "Step: 28 Steady State: 0.6703115701675415\n",
+      "Step: 29 Steady State: 0.6773026585578918\n",
+      "Step: 30 Steady State: 0.6837494373321533\n",
+      "Step: 31 Steady State: 0.6896938681602478\n",
+      "Step: 32 Steady State: 0.6951748728752136\n",
+      "Step: 33 Steady State: 0.7002284526824951\n",
+      "Step: 34 Steady State: 0.7048872113227844\n",
+      "Step: 35 Steady State: 0.7091819047927856\n",
+      "Step: 36 Steady State: 0.7131412029266357\n",
+      "Step: 37 Steady State: 0.7167739868164062\n",
+      "Step: 38 Steady State: 0.7201183438301086\n",
+      "Step: 39 Steady State: 0.7231980562210083\n",
+      "Step: 40 Steady State: 0.7260348796844482\n",
+      "Step: 41 Steady State: 0.7286462187767029\n",
+      "Step: 42 Steady State: 0.7310511469841003\n",
+      "Step: 43 Steady State: 0.733269989490509\n",
+      "Step: 44 Steady State: 0.7353137731552124\n",
+      "Step: 45 Steady State: 0.7371994853019714\n",
+      "Step: 46 Steady State: 0.7389383912086487\n",
+      "Step: 47 Steady State: 0.740541934967041\n",
+      "Step: 48 Steady State: 0.7420334219932556\n",
+      "Step: 49 Steady State: 0.7434003353118896\n",
+      "Step: 50 Steady State: 0.7446598410606384\n",
+      "Step: 51 Steady State: 0.7458205819129944\n",
+      "Step: 52 Steady State: 0.7468900680541992\n",
+      "Step: 53 Steady State: 0.7478761672973633\n",
+      "Step: 54 Steady State: 0.7487852573394775\n",
+      "Step: 55 Steady State: 0.7496234178543091\n",
+      "Step: 56 Steady State: 0.750394344329834\n",
+      "Step: 57 Steady State: 0.7511063814163208\n",
+      "Step: 58 Steady State: 0.751763105392456\n",
+      "Step: 59 Steady State: 0.7523672580718994\n",
+      "Step: 60 Steady State: 0.7529228329658508\n",
+      "Step: 61 Steady State: 0.753433346748352\n",
+      "Step: 62 Steady State: 0.7539049983024597\n",
+      "Step: 63 Steady State: 0.7543382048606873\n",
+      "Step: 64 Steady State: 0.7547407746315002\n",
+      "Step: 65 Steady State: 0.7551127672195435\n",
+      "Step: 66 Steady State: 0.7554563879966736\n",
+      "Step: 67 Steady State: 0.7557693123817444\n",
+      "Step: 68 Steady State: 0.7560611367225647\n",
+      "Step: 69 Steady State: 0.7563308477401733\n",
+      "Step: 70 Steady State: 0.7565800547599792\n",
+      "Step: 71 Steady State: 0.756810188293457\n",
+      "Step: 72 Steady State: 0.7570226788520813\n",
+      "Step: 73 Steady State: 0.7572163343429565\n",
+      "Step: 74 Steady State: 0.7573966979980469\n",
+      "Step: 75 Steady State: 0.7575633525848389\n",
+      "Step: 76 Steady State: 0.7577127814292908\n",
+      "Step: 77 Steady State: 0.7578537464141846\n",
+      "Step: 78 Steady State: 0.7579842805862427\n",
+      "Step: 79 Steady State: 0.7581048607826233\n",
+      "Step: 80 Steady State: 0.7582123279571533\n",
+      "Step: 81 Steady State: 0.7583134770393372\n",
+      "Step: 82 Steady State: 0.7584078907966614\n",
+      "Step: 83 Steady State: 0.7584953904151917\n",
+      "Step: 84 Steady State: 0.758575975894928\n",
+      "Step: 85 Steady State: 0.7586501836776733\n",
+      "Step: 86 Steady State: 0.7587193250656128\n",
+      "Step: 87 Steady State: 0.7587832808494568\n",
+      "Step: 88 Steady State: 0.7588424682617188\n",
+      "Step: 89 Steady State: 0.7588958144187927\n",
+      "Step: 90 Steady State: 0.7589460015296936\n",
+      "Step: 91 Steady State: 0.7589924931526184\n",
+      "Step: 92 Steady State: 0.7590354681015015\n",
+      "Step: 93 Steady State: 0.7590752243995667\n",
+      "Step: 94 Steady State: 0.7591111063957214\n",
+      "Step: 95 Steady State: 0.7591448426246643\n",
+      "Step: 96 Steady State: 0.7591760754585266\n",
+      "Step: 97 Steady State: 0.7592049241065979\n",
+      "Step: 98 Steady State: 0.7592315673828125\n",
+      "Step: 99 Steady State: 0.7592562437057495\n",
+      "Target: 0.7599999904632568\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = ExponentialDecayToSteadyState(\n",
+    "    jnp.array(0.0)\n",
+    ")  # initial steady state guess is 0.\n",
+    "# target steady state is 0.76\n",
+    "target_steady_state = jnp.array(0.76)\n",
+    "optim = optax.sgd(1e-2, momentum=0.7, nesterov=True)\n",
+    "opt_state = optim.init(model)\n",
+    "\n",
+    "\n",
+    "@eqx.filter_jit\n",
+    "def make_step(model, opt_state, target_steady_state):\n",
+    "    grads = eqx.filter_grad(loss)(model, target_steady_state)\n",
+    "    updates, opt_state = optim.update(grads, opt_state)\n",
+    "    model = eqx.apply_updates(model, updates)\n",
+    "    return model, opt_state\n",
+    "\n",
+    "\n",
+    "for step in range(100):\n",
+    "    model, opt_state = make_step(model, opt_state, target_steady_state)\n",
+    "    print(f\"Step: {step} Steady State: {model.steady_state}\")\n",
+    "print(f\"Target: {target_steady_state}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py37",
+   "language": "python",
+   "name": "py37"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
         - Continuous Normalising Flow: 'examples/continuous_normalising_flow.ipynb'
         - Symbolic Regression: 'examples/symbolic_regression.ipynb'
         - Stiff ODE: 'examples/stiff_ode.ipynb'
+        - Steady State: 'examples/steady_state.ipynb'
     - Basic API:
         - 'api/type_terminology.md'
         - 'api/diffeqsolve.md'
@@ -117,6 +118,7 @@ nav:
         - 'api/solution.md'
     - Advanced API:
         - 'api/adjoints.md'
+        - 'api/events.md'
         - 'api/terms.md'
         - 'api/path.md'
         - 'api/interpolation.md'

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -27,13 +27,52 @@ all_ode_solvers = (
     (diffrax.ReversibleHeun, {}),
     (diffrax.Tsit5, dict(scan_stages=False)),
     (diffrax.Tsit5, dict(scan_stages=True)),
-    (diffrax.ImplicitEuler, {}),
-    (diffrax.Kvaerno3, dict(scan_stages=False)),
-    (diffrax.Kvaerno3, dict(scan_stages=True)),
-    (diffrax.Kvaerno4, dict(scan_stages=False)),
-    (diffrax.Kvaerno4, dict(scan_stages=True)),
-    (diffrax.Kvaerno5, dict(scan_stages=False)),
-    (diffrax.Kvaerno5, dict(scan_stages=True)),
+    (
+        diffrax.ImplicitEuler,
+        dict(nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6)),
+    ),
+    (
+        diffrax.Kvaerno3,
+        dict(
+            scan_stages=False,
+            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
+        ),
+    ),
+    (
+        diffrax.Kvaerno3,
+        dict(
+            scan_stages=True,
+            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
+        ),
+    ),
+    (
+        diffrax.Kvaerno4,
+        dict(
+            scan_stages=False,
+            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
+        ),
+    ),
+    (
+        diffrax.Kvaerno4,
+        dict(
+            scan_stages=True,
+            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
+        ),
+    ),
+    (
+        diffrax.Kvaerno5,
+        dict(
+            scan_stages=False,
+            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
+        ),
+    ),
+    (
+        diffrax.Kvaerno5,
+        dict(
+            scan_stages=True,
+            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
+        ),
+    ),
 )
 
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -4,76 +4,48 @@ import operator
 import time
 
 import diffrax
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 
 
 all_ode_solvers = (
-    (diffrax.Bosh3, dict(scan_stages=False)),
-    (diffrax.Bosh3, dict(scan_stages=True)),
-    (diffrax.Dopri5, dict(scan_stages=False)),
-    (diffrax.Dopri5, dict(scan_stages=True)),
-    (diffrax.Dopri8, dict(scan_stages=False)),
-    (diffrax.Dopri8, dict(scan_stages=True)),
-    (diffrax.Euler, {}),
-    (diffrax.Ralston, dict(scan_stages=False)),
-    (diffrax.Ralston, dict(scan_stages=True)),
-    (diffrax.Midpoint, dict(scan_stages=False)),
-    (diffrax.Midpoint, dict(scan_stages=True)),
-    (diffrax.Heun, dict(scan_stages=False)),
-    (diffrax.Heun, dict(scan_stages=True)),
-    (diffrax.LeapfrogMidpoint, {}),
-    (diffrax.ReversibleHeun, {}),
-    (diffrax.Tsit5, dict(scan_stages=False)),
-    (diffrax.Tsit5, dict(scan_stages=True)),
-    (
-        diffrax.ImplicitEuler,
-        dict(nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6)),
-    ),
-    (
-        diffrax.Kvaerno3,
-        dict(
-            scan_stages=False,
-            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
-        ),
-    ),
-    (
-        diffrax.Kvaerno3,
-        dict(
-            scan_stages=True,
-            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
-        ),
-    ),
-    (
-        diffrax.Kvaerno4,
-        dict(
-            scan_stages=False,
-            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
-        ),
-    ),
-    (
-        diffrax.Kvaerno4,
-        dict(
-            scan_stages=True,
-            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
-        ),
-    ),
-    (
-        diffrax.Kvaerno5,
-        dict(
-            scan_stages=False,
-            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
-        ),
-    ),
-    (
-        diffrax.Kvaerno5,
-        dict(
-            scan_stages=True,
-            nonlinear_solver=diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6),
-        ),
-    ),
+    diffrax.Bosh3(scan_stages=False),
+    diffrax.Bosh3(scan_stages=True),
+    diffrax.Dopri5(scan_stages=False),
+    diffrax.Dopri5(scan_stages=True),
+    diffrax.Dopri8(scan_stages=False),
+    diffrax.Dopri8(scan_stages=True),
+    diffrax.Euler(),
+    diffrax.Ralston(scan_stages=False),
+    diffrax.Ralston(scan_stages=True),
+    diffrax.Midpoint(scan_stages=False),
+    diffrax.Midpoint(scan_stages=True),
+    diffrax.Heun(scan_stages=False),
+    diffrax.Heun(scan_stages=True),
+    diffrax.LeapfrogMidpoint(),
+    diffrax.ReversibleHeun(),
+    diffrax.Tsit5(scan_stages=False),
+    diffrax.Tsit5(scan_stages=True),
+    diffrax.ImplicitEuler(),
+    diffrax.Kvaerno3(scan_stages=False),
+    diffrax.Kvaerno3(scan_stages=True),
+    diffrax.Kvaerno4(scan_stages=False),
+    diffrax.Kvaerno4(scan_stages=True),
+    diffrax.Kvaerno5(scan_stages=False),
+    diffrax.Kvaerno5(scan_stages=True),
 )
+
+
+def implicit_tol(solver):
+    if isinstance(solver, diffrax.AbstractAdaptiveSolver):
+        return eqx.tree_at(
+            lambda s: (s.nonlinear_solver.rtol, s.nonlinear_solver.atol),
+            solver,
+            (1e-3, 1e-6),
+        )
+    return solver
 
 
 def random_pytree(key, treedef):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -39,11 +39,12 @@ all_ode_solvers = (
 
 
 def implicit_tol(solver):
-    if isinstance(solver, diffrax.AbstractAdaptiveSolver):
+    if isinstance(solver, diffrax.AbstractImplicitSolver):
         return eqx.tree_at(
             lambda s: (s.nonlinear_solver.rtol, s.nonlinear_solver.atol),
             solver,
             (1e-3, 1e-6),
+            is_leaf=lambda x: x is None,
         )
     return solver
 

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -1,9 +1,11 @@
 import math
+from typing import Any
 
 import diffrax
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import optax
 import pytest
 
 from .helpers import shaped_allclose
@@ -141,3 +143,56 @@ def test_adjoint_seminorm():
         return jnp.sum(sol.ys)
 
     jax.grad(solve)(2.0)
+
+
+def test_implicit():
+    class ExponentialDecayToSteadyState(eqx.Module):
+        steady_state: float
+        non_jax_type: Any
+
+        def __call__(self, t, y, args):
+            return self.steady_state - y
+
+    def loss(model, target_steady_state):
+        term = diffrax.ODETerm(model)
+        solver = diffrax.Tsit5()
+        t0 = 0
+        t1 = jnp.inf
+        dt0 = None
+        y0 = 1.0
+        max_steps = None
+        controller = diffrax.PIDController(rtol=1e-3, atol=1e-6)
+        event = diffrax.SteadyStateEvent()
+        adjoint = diffrax.ImplicitAdjoint()
+        sol = diffrax.diffeqsolve(
+            term,
+            solver,
+            t0,
+            t1,
+            dt0,
+            y0,
+            max_steps=max_steps,
+            stepsize_controller=controller,
+            discrete_terminating_event=event,
+            adjoint=adjoint,
+        )
+        (y1,) = sol.ys
+        return (y1 - target_steady_state) ** 2
+
+    model = ExponentialDecayToSteadyState(jnp.array(0.0), object())
+    target_steady_state = jnp.array(0.76)
+    optim = optax.sgd(1e-2, momentum=0.7, nesterov=True)
+    opt_state = optim.init(eqx.filter(model, eqx.is_array))
+
+    @eqx.filter_jit
+    def make_step(model, opt_state, target_steady_state):
+        grads = eqx.filter_grad(loss)(model, target_steady_state)
+        updates, opt_state = optim.update(grads, opt_state)
+        model = eqx.apply_updates(model, updates)
+        return model, opt_state
+
+    for step in range(100):
+        model, opt_state = make_step(model, opt_state, target_steady_state)
+    assert shaped_allclose(
+        model.steady_state, target_steady_state, rtol=1e-2, atol=1e-2
+    )

--- a/test/test_detest.py
+++ b/test/test_detest.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 import pytest
 import scipy.integrate as integrate
 
-from .helpers import all_ode_solvers, shaped_allclose
+from .helpers import all_ode_solvers, implicit_tol, shaped_allclose
 
 
 #
@@ -393,6 +393,7 @@ def _test(solver, problems, higher):
             return
         max_steps = 16**4
         if not isinstance(solver, diffrax.AbstractAdaptiveSolver):
+            solver = implicit_tol(solver)
             dt0 = 0.01
             if type(solver) is diffrax.LeapfrogMidpoint:
                 # This is an *awful* long-time-horizon solver.

--- a/test/test_detest.py
+++ b/test/test_detest.py
@@ -355,47 +355,46 @@ def _e5():
     return diffeq, init
 
 
-@pytest.mark.parametrize("solver_ctr,solver_kwargs", all_ode_solvers)
-def test_a(solver_ctr, solver_kwargs):
-    if solver_ctr in (diffrax.Euler, diffrax.ImplicitEuler):
+@pytest.mark.parametrize("solver", all_ode_solvers)
+def test_a(solver):
+    if isinstance(solver, (diffrax.Euler, diffrax.ImplicitEuler)):
         # Euler is pretty bad at solving things, so only do some simple tests.
-        _test(solver_ctr, solver_kwargs, [_a1, _a2], higher=False)
+        _test(solver, [_a1, _a2], higher=False)
     else:
-        _test(solver_ctr, solver_kwargs, [_a1, _a2, _a3, _a4, _a5], higher=False)
+        _test(solver, [_a1, _a2, _a3, _a4, _a5], higher=False)
 
 
-@pytest.mark.parametrize("solver_ctr,solver_kwargs", all_ode_solvers)
-def test_b(solver_ctr, solver_kwargs):
-    _test(solver_ctr, solver_kwargs, [_b1, _b2, _b3, _b4, _b5], higher=True)
+@pytest.mark.parametrize("solver", all_ode_solvers)
+def test_b(solver):
+    _test(solver, [_b1, _b2, _b3, _b4, _b5], higher=True)
 
 
-@pytest.mark.parametrize("solver_ctr,solver_kwargs", all_ode_solvers)
-def test_c(solver_ctr, solver_kwargs):
-    _test(solver_ctr, solver_kwargs, [_c1, _c2, _c3, _c4, _c5], higher=True)
+@pytest.mark.parametrize("solver", all_ode_solvers)
+def test_c(solver):
+    _test(solver, [_c1, _c2, _c3, _c4, _c5], higher=True)
 
 
-@pytest.mark.parametrize("solver_ctr,solver_kwargs", all_ode_solvers)
-def test_d(solver_ctr, solver_kwargs):
-    _test(solver_ctr, solver_kwargs, [_d1, _d2, _d3, _d4, _d5], higher=True)
+@pytest.mark.parametrize("solver", all_ode_solvers)
+def test_d(solver):
+    _test(solver, [_d1, _d2, _d3, _d4, _d5], higher=True)
 
 
-@pytest.mark.parametrize("solver_ctr,solver_kwargs", all_ode_solvers)
-def test_e(solver_ctr, solver_kwargs):
-    _test(solver_ctr, solver_kwargs, [_e1, _e2, _e3, _e4, _e5], higher=True)
+@pytest.mark.parametrize("solver", all_ode_solvers)
+def test_e(solver):
+    _test(solver, [_e1, _e2, _e3, _e4, _e5], higher=True)
 
 
-def _test(solver_ctr, solver_kwargs, problems, higher):
+def _test(solver, problems, higher):
     for problem in problems:
         vector_field, init = problem()
         term = diffrax.ODETerm(vector_field)
-        solver = solver_ctr(**solver_kwargs)
         if higher and solver.order(term) < 4:
             # Too difficult to get accurate solutions with a low-order solver
             return
         max_steps = 16**4
-        if not issubclass(solver_ctr, diffrax.AbstractAdaptiveSolver):
+        if not isinstance(solver, diffrax.AbstractAdaptiveSolver):
             dt0 = 0.01
-            if solver_ctr is diffrax.LeapfrogMidpoint:
+            if type(solver) is diffrax.LeapfrogMidpoint:
                 # This is an *awful* long-time-horizon solver.
                 # It gets decent results to begin with, but then the oscillations
                 # build up by t=20.
@@ -403,7 +402,7 @@ def _test(solver_ctr, solver_kwargs, problems, higher):
                 dt0 = 0.000001
                 max_steps = 20_000_001
             stepsize_controller = diffrax.ConstantStepSize()
-        elif solver_ctr is diffrax.ReversibleHeun and problem is _a1:
+        elif type(solver) is diffrax.ReversibleHeun and problem is _a1:
             # ReversibleHeun is a bit like LeapfrogMidpoint, and therefore bad over
             # long time horizons. (It develops very large oscillations over long time
             # horizons.)

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -1,0 +1,33 @@
+import diffrax
+import jax.numpy as jnp
+
+
+def test_discrete_terminate1():
+    term = diffrax.ODETerm(lambda t, y, args: y)
+    solver = diffrax.Tsit5()
+    t0 = 0
+    t1 = jnp.inf
+    dt0 = 1
+    y0 = 1.0
+    event = diffrax.DiscreteTerminatingEvent(lambda state, **kwargs: state.y > 10)
+    sol = diffrax.diffeqsolve(
+        term, solver, t0, t1, dt0, y0, discrete_terminating_event=event
+    )
+    assert jnp.all(sol.ys > 10)
+
+
+def test_discrete_terminate2():
+    term = diffrax.ODETerm(lambda t, y, args: y)
+    solver = diffrax.Tsit5()
+    t0 = 0
+    t1 = jnp.inf
+    dt0 = 1
+    y0 = 1.0
+    event = diffrax.DiscreteTerminatingEvent(lambda state, **kwargs: state.tprev > 10)
+    sol = diffrax.diffeqsolve(
+        term, solver, t0, t1, dt0, y0, discrete_terminating_event=event
+    )
+    assert jnp.all(sol.ts > 10)
+
+
+# diffrax.SteadyStateEvent tested as part of test_adjoint.py::test_implicit

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -10,7 +10,13 @@ import pytest
 import scipy.stats
 from diffrax.misc import ω
 
-from .helpers import all_ode_solvers, random_pytree, shaped_allclose, treedefs
+from .helpers import (
+    all_ode_solvers,
+    implicit_tol,
+    random_pytree,
+    shaped_allclose,
+    treedefs,
+)
 
 
 def _all_pairs(*args):
@@ -108,8 +114,9 @@ def test_basic(solver, t_dtype, treedef, stepsize_controller, getkey):
     assert shaped_allclose(y1, true_y1, atol=1e-2, rtol=1e-2)
 
 
-@pytest.mark.parametrize("solver_ctr,solver_kwargs", all_ode_solvers)
-def test_ode_order(solver_ctr, solver_kwargs):
+@pytest.mark.parametrize("solver", all_ode_solvers)
+def test_ode_order(solver):
+    solver = implicit_tol(solver)
     key = jrandom.PRNGKey(5678)
     akey, ykey = jrandom.split(key, 2)
 
@@ -119,7 +126,6 @@ def test_ode_order(solver_ctr, solver_kwargs):
         return A @ y
 
     term = diffrax.ODETerm(f)
-    solver = solver_ctr(**solver_kwargs)
     t0 = 0
     t1 = 4
     y0 = jrandom.normal(ykey, (10,), dtype=jnp.float64)

--- a/test/test_newton_solver.py
+++ b/test/test_newton_solver.py
@@ -20,7 +20,7 @@ def _fn2(x, args):
     return a - b, b
 
 
-# Nontrivial nteractions between inputs
+# Nontrivial interactions between inputs
 @jax.jit
 def _fn3(x, args):
     mlp = eqx.nn.MLP(4, 4, 256, 2, key=jrandom.PRNGKey(678))


### PR DESCRIPTION
CC @FedericoV 

- Feature: `ImplicitAdjoint`, for backpropagating through an ODE solve via the implicit function theorem.
- Feature: `AbstractDiscreteTerminatingEvent`, `DiscreteTerminatingEvent`, `SteadyStateEvent` for detecting steady states and terminating the solve when they are hit.
- Example: a steady-state solving example demonstrating how to use the new features.
- Refactor: a generic `implicit_jvp` for doing IFT-based backpropagation, used for both `ImplicitAdjoint` and `AbstractNonlinearSolver`.
- Change: `NewtonNonlinearSolver` no longer has a default `rtol`, `atol` if used with a non-adaptive step size controller.

Partly resolves #13, one of the most long-standing issues in this library! There's several other kinds of event handling we could look to add -- continuous terminating events, continuous non-terminating events, discrete non-terminating events, but for now I've focused on just the bit needed to handle efficient location and backpropagation through steady state seeking.