### PR TITLE
Fixed `ImplicitEuler` having a funny warning message. Removed `AbstractStepSizeController.wrap_solver` method

### DIFF
--- a/diffrax/nonlinear_solver/base.py
+++ b/diffrax/nonlinear_solver/base.py
@@ -40,8 +40,8 @@ class AbstractNonlinearSolver(eqx.Module):
     Subclasses will be differentiable via the implicit function theorem.
     """
 
-    rtol: Optional[Scalar] = None
-    atol: Optional[Scalar] = None
+    rtol: Scalar
+    atol: Scalar
 
     @abc.abstractmethod
     def _solve(

--- a/diffrax/nonlinear_solver/newton.py
+++ b/diffrax/nonlinear_solver/newton.py
@@ -93,20 +93,6 @@ class NewtonNonlinearSolver(AbstractNonlinearSolver):
         diff_args: PyTree,
     ) -> Tuple[PyTree, RESULTS]:
         args = eqx.combine(nondiff_args, diff_args)
-        if self.rtol is None or self.atol is None:
-            raise ValueError(
-                "The `rtol` and `atol` tolerances for `NewtonNonlinearSolver` default "
-                "to the `rtol` and `atol` used with an adaptive step size "
-                "controller (such as `diffrax.PIDController`). Either use an "
-                "adaptive step size controller, or specify these tolerances "
-                "manually.\n"
-                "Note that this changed in Diffrax version 0.2.0. If you want to match "
-                "the previous defaults then specify `rtol=1e-3`, `atol=1e-6`. For "
-                "example:\n"
-                "```\n"
-                "diffrax.NewtonNonlinearSolver(rtol=1e-3, atol=1e-6)\n"
-                "```\n"
-            )
         scale = self.atol + self.rtol * self.norm(x)
         flat, unflatten = fu.ravel_pytree(x)
         if flat.size == 0:

--- a/diffrax/solver/__init__.py
+++ b/diffrax/solver/__init__.py
@@ -6,6 +6,8 @@ from .base import (
     AbstractStratonovichSolver,
     AbstractWrappedSolver,
     HalfSolver,
+    UseControllerAtol,
+    UseControllerRtol,
 )
 from .bosh3 import Bosh3
 from .dopri5 import Dopri5

--- a/diffrax/solver/base.py
+++ b/diffrax/solver/base.py
@@ -163,12 +163,22 @@ class AbstractSolver(eqx.Module, metaclass=_MetaAbstractSolver):
         """
 
 
+class UseControllerAtol(eqx.Module):
+    pass
+
+
+class UseControllerRtol(eqx.Module):
+    pass
+
+
 class AbstractImplicitSolver(AbstractSolver):
     """Indicates that this is an implicit differential equation solver, and as such
     that it should take a nonlinear solver as an argument.
     """
 
-    nonlinear_solver: AbstractNonlinearSolver = NewtonNonlinearSolver()
+    nonlinear_solver: AbstractNonlinearSolver = NewtonNonlinearSolver(
+        atol=UseControllerAtol(), rtol=UseControllerRtol()
+    )
 
 
 AbstractImplicitSolver.__init__.__doc__ = """**Arguments:**

--- a/diffrax/step_size_controller/adaptive.py
+++ b/diffrax/step_size_controller/adaptive.py
@@ -10,7 +10,6 @@ import jax.tree_util as jtu
 from ..custom_types import Array, Bool, PyTree, Scalar
 from ..misc import nextafter, prevbefore, rms_norm, ω
 from ..solution import RESULTS
-from ..solver import AbstractImplicitSolver, AbstractSolver
 from ..term import AbstractTerm
 from .base import AbstractStepSizeController
 
@@ -86,25 +85,6 @@ class AbstractAdaptiveStepSizeController(AbstractStepSizeController):
                 "diffrax.PIDController(rtol=1e-3, atol=1e-6)\n"
                 "```\n"
             )
-
-    def wrap_solver(self, solver: AbstractSolver) -> AbstractSolver:
-        # Poor man's multiple dispatch
-        if isinstance(solver, AbstractImplicitSolver):
-            if solver.nonlinear_solver.rtol is None:
-                solver = eqx.tree_at(
-                    lambda s: s.nonlinear_solver.rtol,
-                    solver,
-                    self.rtol,
-                    is_leaf=lambda x: x is None,
-                )
-            if solver.nonlinear_solver.atol is None:
-                solver = eqx.tree_at(
-                    lambda s: s.nonlinear_solver.atol,
-                    solver,
-                    self.atol,
-                    is_leaf=lambda x: x is None,
-                )
-        return solver
 
 
 # https://diffeq.sciml.ai/stable/extras/timestepping/

--- a/diffrax/step_size_controller/base.py
+++ b/diffrax/step_size_controller/base.py
@@ -5,7 +5,6 @@ import equinox as eqx
 
 from ..custom_types import Bool, PyTree, Scalar
 from ..solution import RESULTS
-from ..solver import AbstractSolver
 from ..term import AbstractTerm
 
 
@@ -32,23 +31,6 @@ class AbstractStepSizeController(eqx.Module):
         A copy of the the step size controller, updated to reflect the additional
         information.
         """
-
-    def wrap_solver(self, solver: AbstractSolver) -> AbstractSolver:
-        """Remakes the solver, adding additional information.
-
-        Some step size controllers need to modify the solver slightly. For example,
-        adaptive step size controllers can automatically set the tolerances used in
-        implicit solvers.
-
-        **Arguments:**
-
-        - `solver`: The solver to modify.
-
-        **Returns:**
-
-        The modified solver.
-        """
-        return solver
 
     @abc.abstractmethod
     def init(

--- a/docs/api/stepsize_controller.md
+++ b/docs/api/stepsize_controller.md
@@ -17,7 +17,6 @@ The list of step size controllers is as follows. The most common cases are fixed
         selection:
             members:
                 - wrap
-                - wrap_solver
                 - init
                 - adapt_step_size
 


### PR DESCRIPTION
Fixes #156.

Ideally we should add `UseController{A,R}tol` to the documentation, too.