### PR TITLE
[WIP] Delay differential equations

### DIFF
--- a/diffrax/term.py
+++ b/diffrax/term.py
@@ -152,6 +152,13 @@ class AbstractTerm(eqx.Module):
         return False
 
 
+class VectorFieldWrapper(eqx.Module):
+    vector_field: Callable[[Scalar, PyTree, PyTree], PyTree]
+
+    def __call__(self, t, y, args):
+        return self.vector_field(t, y, args)
+
+
 class ODETerm(AbstractTerm):
     r"""A term representing $f(t, y(t), args) \mathrm{d}t$. That is to say, the term
     appearing on the right hand side of an ODE, in which the control is time.
@@ -168,6 +175,9 @@ class ODETerm(AbstractTerm):
         ```
     """
     vector_field: Callable[[Scalar, PyTree, PyTree], PyTree]
+
+    def __init__(self, vector_field):
+        self.vector_field = VectorFieldWrapper(vector_field)
 
     def vf(self, t: Scalar, y: PyTree, args: PyTree) -> PyTree:
         return self.vector_field(t, y, args)
@@ -199,6 +209,10 @@ def _prod(
 class _ControlTerm(AbstractTerm):
     vector_field: Callable[[Scalar, PyTree, PyTree], PyTree]
     control: AbstractPath
+
+    def __init__(self, vector_field, control):
+        self.vector_field = VectorFieldWrapper(vector_field)
+        self.control = control
 
     def vf(self, t: Scalar, y: PyTree, args: PyTree) -> PyTree:
         return self.vector_field(t, y, args)


### PR DESCRIPTION
@thibmonsel

This is a quick WIP draft of how we might add support for delay diffeqs into Diffrax.

The goal is to make the API follow:
```python
def vector_field(t, y, args, *, history):
    ...

delays = [lambda t, y, args: 1.0,
          lambda t, y, args: max(y, 1)]

diffeqsolve(ODETerm(vector_field), ..., delays=delays)
```

There's several pieces that still need doing:
- The nonlinear solve, with respect to the dense solution over each step. (E.g. as per Section 4.1 of the DelayDiffEq.jl paper)
- Detecting discontinuities and stepping to them directly. (Section 4.2)
- Possibly add special support for "nice" delays, that we might be able to handle more efficiently? E.g. as long as our minimal delay is larger than our step size then the nonlinear solve can be skipped.
- Adding documentation.
- Adding an example.
- Probably now would be a good time to figure out how to add support for solving DAEs as well (e.g. see #62). Both involve a nonlinear solve, and both involve passing extra information to the user-provided vector field. It might be that we can make use the same mechanisms for both. (And at the very least we should ensure that any choices we make now don't negatively impact DAE support later.)