### PR TITLE
use jnp.nanmin and jnp.nanmax to compute new stepsize factor 

### DIFF
--- a/diffrax/step_size_controller/adaptive.py
+++ b/diffrax/step_size_controller/adaptive.py
@@ -496,11 +496,7 @@ class PIDController(AbstractAdaptiveStepSizeController):
         factor2 = 1 if _zero_coeff(coeff2) else prev_inv_scaled_error ** coeff2
         factor3 = 1 if _zero_coeff(coeff3) else prev_prev_inv_scaled_error ** coeff3
         factormin = jnp.where(keep_step, 1, self.factormin)
-        factor = jnp.clip(
-            self.safety * factor1 * factor2 * factor3,
-            a_min=factormin,
-            a_max=self.factormax,
-        )
+        factor = jnp.nanmin(jnp.array([self.factormax, jnp.nanmax(jnp.array([self.safety * factor1 * factor2 * factor3, factormin]))]))
         # Once again, see above. In case we have gradients on {i,p,d}coeff.
         # (Probably quite common for them to have zero tangents if passed across
         # a grad API boundary as part of a larger model.)


### PR DESCRIPTION
…instead of of jnp.clip in diffrax.step_size_controller.adaptive.adapt_step_size()

Care was taken to make sure that the order of jnp.nanmin and jnp.nanmax reflects the actual behavior of jnp.clip. According to https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.clip.html, using jnp.(nan)min and jnp.(nan)max may be a bit slower than  jnp.clip but at least it will be robust against NaN's in y_error.

This solves https://github.com/patrick-kidger/diffrax/issues/223 and is similar to my proposed bugfix / pull request for jax.experimental.ode.optimal_step_size() here: https://github.com/google/jax/issues/14612 and https://github.com/google/jax/pull/14624 

I confirmed that this works with different explicit/implicit diffrax solvers and I get the expected correct solution to my non-autonomous ODE system vs. scipy.integrate.solve_ivp, manual non-adaptive Euler integration with extremely small timesteps, and manual adaptive RK23 (Bogacki-Shampine) solver in both pure python and JAX.