### PR TITLE
Explicitly marked BacksolveAdjoint as incompatible with events.

### DIFF
--- a/diffrax/adjoint.py
+++ b/diffrax/adjoint.py
@@ -530,6 +530,7 @@ def _loop_backsolve_bwd(
     throw,
     init_state,
 ):
+    assert discrete_terminating_event is None
 
     #
     # Unpack our various arguments. Delete a lot of things just to make sure we're not
@@ -565,7 +566,6 @@ def _loop_backsolve_bwd(
         adjoint=self,
         solver=solver,
         stepsize_controller=stepsize_controller,
-        discrete_terminating_event=discrete_terminating_event,
         terms=adjoint_terms,
         dt0=None if dt0 is None else -dt0,
         max_steps=max_steps,
@@ -744,6 +744,7 @@ class BacksolveAdjoint(AbstractAdjoint):
         init_state,
         passed_solver_state,
         passed_controller_state,
+        discrete_terminating_event,
         **kwargs,
     ):
         if jtu.tree_structure(saveat.subs, is_leaf=_is_subsaveat) != jtu.tree_structure(
@@ -785,6 +786,10 @@ class BacksolveAdjoint(AbstractAdjoint):
                 "`diffrax.BacksolveAdjoint` is only compatible with solvers that take "
                 "a single term."
             )
+        if discrete_terminating_event is not None:
+            raise NotImplementedError(
+                "`diffrax.BacksolveAdjoint` is not compatible with events."
+            )
 
         y = init_state.y
         init_state = eqx.tree_at(lambda s: s.y, init_state, object())
@@ -798,6 +803,7 @@ class BacksolveAdjoint(AbstractAdjoint):
             saveat=saveat,
             init_state=init_state,
             solver=solver,
+            discrete_terminating_event=discrete_terminating_event,
             **kwargs,
         )
         final_state = _only_transpose_ys(final_state)


### PR DESCRIPTION
Fixes #294.