### PR TITLE
Fixed BacksolveAdjoint+VirtualBrownianTree on TPU without JIT.

### DIFF
--- a/diffrax/term.py
+++ b/diffrax/term.py
@@ -409,7 +409,9 @@ class WrapTerm(AbstractTerm):
         y: Tuple[PyTree, PyTree, PyTree, PyTree],
         args: PyTree,
     ) -> bool:
-        return self.term.is_vf_expensive(t0, t1, y, args)
+        _t0 = jnp.where(self.direction == 1, t0, -t1)
+        _t1 = jnp.where(self.direction == 1, t1, -t0)
+        return self.term.is_vf_expensive(_t0, _t1, y, args)
 
 
 class AdjointTerm(AbstractTerm):
@@ -422,8 +424,8 @@ class AdjointTerm(AbstractTerm):
         y: Tuple[PyTree, PyTree, PyTree, PyTree],
         args: PyTree,
     ) -> bool:
-        control = self.contr(t0, t1)
-        if sum(c.size for c in jtu.tree_leaves(control)) in (0, 1):
+        control_struct = jax.eval_shape(self.contr, t0, t1)
+        if sum(c.size for c in jtu.tree_leaves(control_struct)) in (0, 1):
             return False
         else:
             return True


### PR DESCRIPTION
Quite the edge case! This combination was hitting an error in which
the VirtualBrownianTree refused to be evaluated outside of [t0, t1].

The proximal cause turned out to be that `WrapTerm.is_vf_expensive` was
missing a couple of lines to flip around t0 and t1 if solving
backwards-in-time. Backwards-in-time solves occur most commonly when
using BacksolveAdjoint.

The lack of JIT is important as this call can actually be DCE'd: it is
only used for its static metadata, not its runtime value. So this
error does not appear when running under JIT, which is also the reason
it didn't get caught in our tests.

The final piece of the puzzle, TPUs, is still a bit of a mystery. That
the error should be raised when running eagerly makes sense. What is
surprising is that CPU-vs-TPU seem to have different behaviour here.
Why does CPU DCE this at all?
