### PR TITLE
Fix for `disable_jit` causing crashes.

### DIFF
--- a/diffrax/integrate.py
+++ b/diffrax/integrate.py
@@ -415,6 +415,11 @@ def loop(
             )
             new_state = eqx.tree_at(lambda s: s.result, new_state, result)
 
+        if not _filtering:
+            # This is only necessary for Equinox <0.11.1.
+            # After that, this fix has been upstreamed to Equinox.
+            # TODO: remove once we make Equinox >=0.11.1 required.
+            new_state = jtu.tree_map(jnp.array, new_state)
         return new_state
 
     _filtering = True

--- a/diffrax/nonlinear_solver/newton.py
+++ b/diffrax/nonlinear_solver/newton.py
@@ -141,7 +141,7 @@ class NewtonNonlinearSolver(AbstractNonlinearSolver):
             val = (flat, step + 1, diffsize, diffsize_prev)
             return val
 
-        val = (flat, 0, 0.0, 0.0)
+        val = (flat, 0, jnp.array(0.0), jnp.array(0.0))
         val = lax.while_loop(cond_fn, body_fn, val)
         flat, num_steps, diffsize, diffsize_prev = val
 

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -418,3 +418,27 @@ def test_concrete_made_jump():
             assert sol.made_jump is False
 
         run(1)
+
+
+def test_no_jit():
+    # https://github.com/patrick-kidger/diffrax/issues/293
+    # https://github.com/patrick-kidger/diffrax/issues/321
+
+    # Test that this doesn't crash.
+    with jax.disable_jit():
+
+        def vector_field(t, y, args):
+            return jnp.zeros_like(y)
+
+        term = diffrax.ODETerm(vector_field)
+        y = jnp.zeros((1,))
+        stepsize_controller = diffrax.PIDController(rtol=1e-5, atol=1e-5)
+        diffrax.diffeqsolve(
+            term,
+            diffrax.Kvaerno4(),
+            t0=0,
+            t1=1e-2,
+            dt0=1e-3,
+            stepsize_controller=stepsize_controller,
+            y0=y,
+        )


### PR DESCRIPTION
This was due to (a) a division-by-zero error arising from not casting to an array, and (b) an issue with JAX not promoting arraylikes to arrays under disable_jit.

Fixes #293.
Fixes #321.