### PR TITLE
Now using strict shape/dtype promotion rules.

### DIFF
--- a/diffrax/_brownian/tree.py
+++ b/diffrax/_brownian/tree.py
@@ -9,6 +9,7 @@ import jax.lax as lax
 import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
+import lineax.internal as lxi
 from jaxtyping import Array, Float, PRNGKeyArray, PyTree
 
 from .._custom_types import (
@@ -20,7 +21,6 @@ from .._custom_types import (
     RealScalarLike,
 )
 from .._misc import (
-    default_floating_dtype,
     is_tuple_of_ints,
     linear_rescale,
     split_by_tree,
@@ -179,7 +179,7 @@ class VirtualBrownianTree(AbstractBrownianPath):
         self.levy_area = levy_area
         self._spline = _spline
         self.shape = (
-            jax.ShapeDtypeStruct(shape, default_floating_dtype())
+            jax.ShapeDtypeStruct(shape, lxi.default_floating_dtype())
             if is_tuple_of_ints(shape)
             else shape
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 
 jax.config.update("jax_enable_x64", True)  # pyright: ignore
+jax.config.update("jax_numpy_rank_promotion", "raise")  # pyright: ignore
+jax.config.update("jax_numpy_dtype_promotion", "strict")  # pyright: ignore
 
 
 @pytest.fixture()

--- a/test/test_adaptive_stepsize_controller.py
+++ b/test/test_adaptive_stepsize_controller.py
@@ -83,7 +83,8 @@ def test_backprop():
         _, tprev, tnext, _, state, _ = controller.adapt_step_size(
             0, 1, y0, y1_candidate, None, y_error, 5, state
         )
-        return tprev + tnext + sum(jnp.sum(x) for x in jtu.tree_leaves(state))
+        with jax.numpy_dtype_promotion("standard"):
+            return tprev + tnext + sum(jnp.sum(x) for x in jtu.tree_leaves(state))
 
     y0 = jnp.array(1.0)
     y1_candidate = jnp.array(2.0)

--- a/test/test_global_interpolation.py
+++ b/test/test_global_interpolation.py
@@ -290,9 +290,10 @@ def test_interpolation_classes(mode, getkey):
 
                     def _test(firstval, vals, y0, y1):
                         vals = jnp.concatenate([firstval[None], vals])
-                        true_vals = y0 + ((points - t0) / (t1 - t0))[:, None] * (
-                            y1 - y0
-                        )
+                        with jax.numpy_rank_promotion("allow"):
+                            true_vals = y0 + ((points - t0) / (t1 - t0))[:, None] * (
+                                y1 - y0
+                            )
                         assert tree_allclose(vals, true_vals)
 
                     jtu.tree_map(_test, firstval, vals, y0, y1)

--- a/test/test_saveat_solution.py
+++ b/test/test_saveat_solution.py
@@ -118,7 +118,8 @@ def test_saveat_solution():
     assert sol.ts.shape == (4096,)  # pyright: ignore
     assert sol.ys.shape == (4096, 1)  # pyright: ignore
     _ts = jnp.where(sol.ts == jnp.inf, jnp.nan, sol.ts)
-    _ys = _y0 * jnp.exp(-0.5 * (_ts - _t0))[:, None]
+    with jax.numpy_rank_promotion("allow"):
+        _ys = _y0 * jnp.exp(-0.5 * (_ts - _t0))[:, None]
     _ys = jnp.where(jnp.isnan(_ys), jnp.inf, _ys)
     assert tree_allclose(sol.ys, _ys)
     assert sol.controller_state is None


### PR DESCRIPTION
This means that:

1. Tests now pass using `JAX_NUMPY_DTYPE_PROMOTION=strict` and `JAX_NUMPY_RANK_PROMOTION=raise`, and these are enabled in tests by default.
2. The values passed to `diffeqsolve` now more carefully determine the dtype used in the integration (previously things were mostly just left to behave in ad-hoc fashion; whatever the various interacting arrays promoted their dtypes to):
    a. The dtype of timelike values is the `jnp.result_type` of `t0`, `t1`, `dt0`, and `SaveAt(ts=...)`. If any of these are complex an error is raised. If these are all integers we use the default floating-point dtype.
    b. The `jnp.result_type` of the time dtype, and each leaf of `y0`, is the dtype of that leaf.
3. Of course, `diffeqsolve` accepts user-specified functions (e.g. the vector field of an `ODETerm`), and these could potentially return arrays with dtypes that do not match the ones we have selected above, which might cause further upcasting. For the sake of backward compatibility we don't try to prohibit this -- a user who feels strongly about this should enable `JAX_NUMPY_DTYPE_PROMOTION=strict` and fix their vector fields appropriately. (And can then be assured that the dtypes of these quantities are exactly as specified by the rules above.) So the key thing this commit enables is that using this flag to enforce this is now possible, without any false positives from Diffrax itself!
