### PR TITLE
Fix a crash and an unclear error message.

### DIFF
--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -368,7 +368,9 @@ class DirectAdjoint(AbstractAdjoint):
         # Support forward-mode autodiff.
         # TODO: remove this hack once we can JVP through custom_vjps.
         if isinstance(solver, AbstractRungeKutta) and solver.scan_kind is None:
-            solver = eqx.tree_at(lambda s: s.scan_kind, solver, "bounded")
+            solver = eqx.tree_at(
+                lambda s: s.scan_kind, solver, "bounded", is_leaf=_is_none
+            )
         inner_while_loop = ft.partial(_inner_loop, kind=kind)
         outer_while_loop = ft.partial(_outer_loop, kind=kind)
         final_state = self._loop(

--- a/diffrax/_root_finder/_with_tols.py
+++ b/diffrax/_root_finder/_with_tols.py
@@ -3,7 +3,15 @@ import jax.numpy as jnp
 import optimistix as optx
 
 
-use_stepsize_tol = object()
+class _UseStepSizeTol:
+    def __repr__(self):
+        return (
+            "<tolerance taken from `diffeqsolve(..., stepsize_controller=...)` "
+            "argument>"
+        )
+
+
+use_stepsize_tol = _UseStepSizeTol()
 
 
 def with_stepsize_controller_tols(cls: type[optx.AbstractRootFinder]):

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -363,3 +363,16 @@ def test_sde_against(getkey):
     grads3 = run((y0, args), diffrax.RecursiveCheckpointAdjoint())
     assert tree_allclose(grads1, grads2, rtol=1e-3, atol=1e-3)
     assert tree_allclose(grads1, grads3, rtol=1e-3, atol=1e-3)
+
+
+def test_implicit_runge_kutta_direct_adjoint():
+    diffrax.diffeqsolve(
+        diffrax.ODETerm(lambda t, y, args: -y),
+        diffrax.Kvaerno5(),
+        0,
+        1,
+        0.01,
+        1.0,
+        adjoint=diffrax.DirectAdjoint(),
+        stepsize_controller=diffrax.PIDController(rtol=1e-3, atol=1e-6),
+    )

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -504,3 +504,16 @@ def test_static(capfd):
         assert text == "static_made_jump=False static_result=None\n"
     finally:
         diffrax._integrate._PRINT_STATIC = False
+
+
+def test_implicit_tol_error():
+    msg = "the tolerances for the implicit solver have not been specified"
+    with pytest.raises(ValueError, match=msg):
+        diffrax.diffeqsolve(
+            diffrax.ODETerm(lambda t, y, args: -y),
+            diffrax.Kvaerno5(),
+            0,
+            1,
+            0.01,
+            1.0,
+        )


### PR DESCRIPTION
1. Fixes a spurious crash when using an implicit solver with DirectAdjoint.
2. Fixes the unclear error message when using an implicit solver without an adaptive step size controller.
