### PR TITLE
Avoid jax.config import

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
 import equinox.internal as eqxi
-import jax.config
+import jax
 import pytest
 
 


### PR DESCRIPTION
The `jax.config` submodule is empty and will soon be removed. The `jax.config` object, which is how configuration is done in this file, only requires `import jax`.