### PR TITLE
got Rid of internally using LevyVal in VBT

### DIFF
--- a/diffrax/_brownian/path.py
+++ b/diffrax/_brownian/path.py
@@ -111,7 +111,7 @@ class UnsafeBrownianPath(AbstractBrownianPath):
             self.shape,
         )
         if use_levy:
-            out = levy_tree_transpose(self.shape, self.levy_area, out)
+            out = levy_tree_transpose(self.shape, out)
             assert isinstance(out, LevyVal)
         return out
 
@@ -137,7 +137,7 @@ class UnsafeBrownianPath(AbstractBrownianPath):
         w = jr.normal(key, shape.shape, shape.dtype) * w_std
 
         if use_levy:
-            return LevyVal(dt=t1 - t0, W=w, H=hh, bar_H=None, K=None, bar_K=None)
+            return LevyVal(dt=t1 - t0, W=w, H=hh, K=None)
         else:
             return w
 

--- a/diffrax/_custom_types.py
+++ b/diffrax/_custom_types.py
@@ -60,12 +60,10 @@ class LevyVal(eqx.Module):
     dt: PyTree
     W: PyTree
     H: Optional[PyTree]
-    bar_H: Optional[PyTree]
     K: Optional[PyTree]
-    bar_K: Optional[PyTree]
 
 
-def levy_tree_transpose(tree_shape, levy_area: LevyArea, tree: PyTree):
+def levy_tree_transpose(tree_shape, tree: PyTree):
     """Helper that takes a PyTree of LevyVals and transposes
     into a LevyVal of PyTrees.
 


### PR DESCRIPTION
Just a quick proposal how to get rid of LevyVal used internally in VBT, meaning that bar_H and bar_K can be removed.
@patrick-kidger @tttc3