### PR TITLE
Fixup test_term static type checking.

### DIFF
--- a/benchmarks/small_neural_ode.py
+++ b/benchmarks/small_neural_ode.py
@@ -20,7 +20,7 @@ from jaxtyping import Array
 class FuncTorch(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.func = torch.jit.script(  # pyright: ignore
+        self.func = torch.jit.script(
             torch.nn.Sequential(
                 torch.nn.Linear(4, 32),
                 torch.nn.Softplus(),
@@ -30,7 +30,7 @@ class FuncTorch(torch.nn.Module):
         )
 
     def forward(self, t, y):
-        return self.func(y)  # pyright: ignore
+        return self.func(y)
 
 
 class FuncJax(eqx.Module):
@@ -177,10 +177,10 @@ def run(multiple, grad, batch_size=64, t1=100):
     with torch.no_grad():
         func_jax = neural_ode_diffrax.func.func
         func_torch = neural_ode_torch.func.func
-        func_torch[0].weight.copy_(torch.tensor(np.asarray(func_jax.layers[0].weight)))  # pyright: ignore
-        func_torch[0].bias.copy_(torch.tensor(np.asarray(func_jax.layers[0].bias)))  # pyright: ignore
-        func_torch[2].weight.copy_(torch.tensor(np.asarray(func_jax.layers[1].weight)))  # pyright: ignore
-        func_torch[2].bias.copy_(torch.tensor(np.asarray(func_jax.layers[1].bias)))  # pyright: ignore
+        func_torch[0].weight.copy_(torch.tensor(np.asarray(func_jax.layers[0].weight)))
+        func_torch[0].bias.copy_(torch.tensor(np.asarray(func_jax.layers[0].bias)))
+        func_torch[2].weight.copy_(torch.tensor(np.asarray(func_jax.layers[1].weight)))
+        func_torch[2].bias.copy_(torch.tensor(np.asarray(func_jax.layers[1].bias)))
 
     y0_jax = jr.normal(jr.PRNGKey(1), (batch_size, 4))
     y0_torch = torch.tensor(np.asarray(y0_jax))

--- a/diffrax/_brownian/path.py
+++ b/diffrax/_brownian/path.py
@@ -64,7 +64,7 @@ class UnsafeBrownianPath(AbstractBrownianPath):
             else shape
         )
         self.key = key
-        self.levy_area = levy_area  # pyright: ignore[reportIncompatibleVariableOverride]
+        self.levy_area = levy_area
 
         if any(
             not jnp.issubdtype(x.dtype, jnp.inexact)
@@ -73,11 +73,11 @@ class UnsafeBrownianPath(AbstractBrownianPath):
             raise ValueError("UnsafeBrownianPath dtypes all have to be floating-point.")
 
     @property
-    def t0(self):  # pyright: ignore[reportIncompatibleVariableOverride]
+    def t0(self):
         return -jnp.inf
 
     @property
-    def t1(self):  # pyright: ignore[reportIncompatibleVariableOverride]
+    def t1(self):
         return jnp.inf
 
     @eqx.filter_jit

--- a/diffrax/_brownian/tree.py
+++ b/diffrax/_brownian/tree.py
@@ -193,12 +193,12 @@ class VirtualBrownianTree(AbstractBrownianPath):
         _spline: _Spline = "sqrt",
     ):
         (t0, t1) = eqx.error_if((t0, t1), t0 >= t1, "t0 must be strictly less than t1")
-        self.t0 = t0  # pyright: ignore[reportIncompatibleVariableOverride]
-        self.t1 = t1  # pyright: ignore[reportIncompatibleVariableOverride]
+        self.t0 = t0
+        self.t1 = t1
         # Since we rescale the interval to [0,1],
         # we need to rescale the tolerance too.
         self.tol = tol / (self.t1 - self.t0)
-        self.levy_area = levy_area  # pyright: ignore[reportIncompatibleVariableOverride]
+        self.levy_area = levy_area
         self._spline = _spline
         self.shape = (
             jax.ShapeDtypeStruct(shape, lxi.default_floating_dtype())

--- a/diffrax/_root_finder/_verychord.py
+++ b/diffrax/_root_finder/_verychord.py
@@ -94,7 +94,7 @@ class VeryChord(optx.AbstractRootFinder):
             linear_state = (jac, init_later_state)
             y_leaves = jtu.tree_leaves(y)
             if len(y_leaves) == 0:
-                y_dtype = lxi.default_floating_dtype()  # pyright: ignore
+                y_dtype = lxi.default_floating_dtype()
             else:
                 y_dtype = jnp.result_type(*y_leaves)
             init_state = _VeryChordState(

--- a/diffrax/_solver/base.py
+++ b/diffrax/_solver/base.py
@@ -28,7 +28,7 @@ _SolverState = TypeVar("_SolverState")
 
 def vector_tree_dot(a, b):
     return jtu.tree_map(
-        lambda bi: jnp.tensordot(a, bi, axes=1, precision=lax.Precision.HIGHEST),  # pyright: ignore
+        lambda bi: jnp.tensordot(a, bi, axes=1, precision=lax.Precision.HIGHEST),
         b,
     )
 

--- a/diffrax/_solver/runge_kutta.py
+++ b/diffrax/_solver/runge_kutta.py
@@ -779,7 +779,7 @@ class AbstractRungeKutta(AbstractAdaptiveSolver[_SolverState]):
 
         y0_leaves = jtu.tree_leaves(y0)
         if len(y0_leaves) == 0:
-            tableau_dtype = lxi.default_floating_dtype()  # pyright: ignore
+            tableau_dtype = lxi.default_floating_dtype()
         else:
             tableau_dtype = jnp.result_type(*y0_leaves)
 
@@ -807,7 +807,7 @@ class AbstractRungeKutta(AbstractAdaptiveSolver[_SolverState]):
             )
             implicit_predictor = np.zeros(
                 (num_stages, num_stages),
-                dtype=np.result_type(*implicit_tableau.a_predictor),  # pyright: ignore
+                dtype=np.result_type(*implicit_tableau.a_predictor),
             )
             for i, a_predictor_i in enumerate(implicit_tableau.a_predictor):  # pyright: ignore
                 implicit_predictor[i + 1, : i + 1] = a_predictor_i

--- a/diffrax/_step_size_controller/adaptive.py
+++ b/diffrax/_step_size_controller/adaptive.py
@@ -453,7 +453,7 @@ class PIDController(
 
         y_leaves = jtu.tree_leaves(y0)
         if len(y_leaves) == 0:
-            y_dtype = lxi.default_floating_dtype()  # pyright: ignore
+            y_dtype = lxi.default_floating_dtype()
         else:
             y_dtype = jnp.result_type(*y_leaves)
         return t1, (

--- a/diffrax/_term.py
+++ b/diffrax/_term.py
@@ -227,11 +227,11 @@ class _CallableToPath(AbstractPath[_Control]):
     fn: Callable
 
     @property
-    def t0(self):  # pyright: ignore[reportIncompatibleVariableOverride]
+    def t0(self):
         return -jnp.inf
 
     @property
-    def t1(self):  # pyright: ignore[reportIncompatibleVariableOverride]
+    def t1(self):
         return jnp.inf
 
     def evaluate(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,5 @@ order-by-type = false
 [tool.pyright]
 reportIncompatibleMethodOverride = true
 reportIncompatibleVariableOverride = false  # Incompatible with eqx.AbstractVar
+reportUnnecessaryTypeIgnoreComment = true
 include = ["diffrax", "tests"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,9 +3,9 @@ import jax
 import pytest
 
 
-jax.config.update("jax_enable_x64", True)  # pyright: ignore
-jax.config.update("jax_numpy_rank_promotion", "raise")  # pyright: ignore
-jax.config.update("jax_numpy_dtype_promotion", "strict")  # pyright: ignore
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_numpy_rank_promotion", "raise")
+jax.config.update("jax_numpy_dtype_promotion", "strict")
 
 
 @pytest.fixture()

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -140,7 +140,7 @@ def test_multiple_tableau1(adaptive):
     with pytest.raises(ValueError):
         diffrax.diffeqsolve(
             (term1, term2),
-            _DoubleDopri5(),  # pyright: ignore
+            _DoubleDopri5(),
             t0,
             t1,
             dt0,

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -55,22 +55,6 @@ def test_control_term(getkey):
     _: diffrax.ControlTerm[PyTree[Array], Array] = term
     __: diffrax.ControlTerm[PyTree[Array], diffrax.AbstractBrownianReturn] = term  # type: ignore
 
-    # Enable the following runtime checks once beartype supports Generic[TypeVar].
-    # https://github.com/beartype/beartype/issues/238
-    # import pytest
-    # from beartype.door import die_if_unbearable
-    # from beartype.roar import BeartypeCallHintViolation
-
-    # control = Control()
-    # term = diffrax.ControlTerm(vector_field, control)
-
-    # die_if_unbearable(term, diffrax.ControlTerm[Shaped[Array, "2"]])
-    # with pytest.raises(BeartypeCallHintViolation):
-    #     die_if_unbearable(term, diffrax.ControlTerm[Shaped[Array, "3"]])
-
-    # with pytest.raises(BeartypeCallHintViolation):
-    #     die_if_unbearable(term, diffrax.ControlTerm[diffrax.LevyVal])
-
     term = term.to_ode()
     dt = term.contr(0, 1)
     vf = term.vf(0, y, args)

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -34,7 +34,7 @@ def test_get_origin_no_specials():
     with pytest.raises(NotImplementedError, match="qwerty"):
         get_origin_no_specials(Union[int, str], "qwerty")
     with pytest.raises(NotImplementedError, match="qwerty"):
-        get_origin_no_specials(Literal[4], "qwerty")  # pyright: ignore
+        get_origin_no_specials(Literal[4], "qwerty")
 
 
 def test_get_args_of_not_generic():


### PR DESCRIPTION
- set reportUnnecessaryTypeIgnoreComment=true, as required by the static type "tests" in `test_term`;

- remove now redundant, commented out, beatype based tests in `test_term`;

- remove all unnecessary type ignore comments from across the codebase.