### PR TITLE
PID for complex dtype fixes

### DIFF
--- a/diffrax/_solver/tsit5.py
+++ b/diffrax/_solver/tsit5.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import ClassVar, Optional
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from equinox.internal import ω
@@ -147,10 +148,11 @@ class _Tsit5Interpolation(AbstractLocalInterpolation):
         )
         b6 = -34.87065786149660974 * (t - 1.2) * (t - 0.666666666666666667) * t**2
         b7 = 2.5 * (t - 1) * (t - 0.6) * t**2
-        return (
-            self.y0**ω
-            + vector_tree_dot(jnp.stack([b1, b2, b3, b4, b5, b6, b7]), self.k) ** ω
-        ).ω
+        with jax.numpy_dtype_promotion("standard"):
+            return (
+                self.y0**ω
+                + vector_tree_dot(jnp.stack([b1, b2, b3, b4, b5, b6, b7]), self.k) ** ω
+            ).ω
 
 
 class Tsit5(AbstractERK):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/diffrax" }
-dependencies = ["jax>=0.4.23", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard==2.13.3", "equinox>=0.11.2", "lineax>=0.0.4", "optimistix>=0.0.6"]
+dependencies = ["jax>=0.4.23", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard==2.13.3", "equinox>=0.11.2", "lineax>=0.0.5", "optimistix>=0.0.6"]
 
 [build-system]
 requires = ["hatchling"]

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -45,27 +45,25 @@ def _all_pairs(*args):
 
 
 @pytest.mark.parametrize(
-    "solver,t_dtype,y_dtype,treedef,stepsize_controller",
-    _all_pairs(
-        dict(
-            default=diffrax.Euler(),
-            opts=(
-                diffrax.LeapfrogMidpoint(),
-                diffrax.ReversibleHeun(),
-                diffrax.Tsit5(),
-                diffrax.ImplicitEuler(
-                    root_finder=diffrax.VeryChord(rtol=1e-3, atol=1e-6)
-                ),
-                diffrax.Kvaerno3(root_finder=diffrax.VeryChord(rtol=1e-3, atol=1e-6)),
-            ),
-        ),
-        dict(default=jnp.float32, opts=(int, float, jnp.int32)),
-        dict(default=jnp.float32, opts=(jnp.complex64,)),
-        dict(default=treedefs[0], opts=treedefs[1:]),
-        dict(
-            default=diffrax.ConstantStepSize(),
-            opts=(diffrax.PIDController(rtol=1e-5, atol=1e-8),),
-        ),
+    "solver",
+    (
+        diffrax.Euler(),
+        diffrax.LeapfrogMidpoint(),
+        diffrax.ReversibleHeun(),
+        diffrax.Tsit5(),
+        diffrax.ImplicitEuler(root_finder=diffrax.VeryChord(rtol=1e-3, atol=1e-6)),
+        diffrax.Kvaerno3(root_finder=diffrax.VeryChord(rtol=1e-3, atol=1e-6)),
+    ),
+)
+@pytest.mark.parametrize("t_dtype", (jnp.float32, int, float, jnp.int32))
+@pytest.mark.parametrize("y_dtype", (jnp.float32, jnp.complex64))
+@pytest.mark.parametrize("treedef", treedefs)
+@pytest.mark.parametrize(
+    "stepsize_controller",
+    (
+        diffrax.ConstantStepSize(),
+        diffrax.PIDController(rtol=1e-5, atol=1e-8),
+        diffrax.PIDController(rtol=1e-5, atol=1e-8, pcoeff=0.3, icoeff=0.3, dcoeff=0.0),
     ),
 )
 def test_basic(solver, t_dtype, y_dtype, treedef, stepsize_controller, getkey):


### PR DESCRIPTION
Depends on https://github.com/patrick-kidger/lineax/pull/91
Should fix https://github.com/patrick-kidger/diffrax/issues/389

More generally, it appears that `caveat` is not tested at all for solvers. From what I can see, the problem in `Tsit5` is not caught by any test (though maybe the relevant test just doesn't run with complex dtypes?). Maybe having a large grid of tests for solver/parameter setups with simple DE can be helpful for these?