### PR TITLE
Improve errors

### DIFF
--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -176,7 +176,10 @@ def _term_compatible(
 
                 contr = ft.partial(term.contr, **term_contr_kwargs)
                 # Work around https://github.com/google/jax/issues/21825
-                control_type = eqx.filter_eval_shape(contr, 0.0, 0.0)
+                try:
+                    control_type = eqx.filter_eval_shape(contr, 0.0, 0.0)
+                except ValueError as e:
+                    raise ValueError(f"Error while tracing {term}.contr: " + str(e))
                 control_type_compatible = eqx.filter_eval_shape(
                     better_isinstance, control_type, control_type_expected
                 )

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -1014,10 +1014,15 @@ def diffeqsolve(
     del timelikes
 
     # Backward compatibility
-    if isinstance(
-        solver, (EulerHeun, ItoMilstein, StratonovichMilstein)
-    ) and _term_compatible(
-        y0, args, terms, (ODETerm, AbstractTerm), solver.term_compatible_contr_kwargs
+    if (
+        isinstance(solver, (EulerHeun, ItoMilstein, StratonovichMilstein))
+        and _term_compatible(
+            y0,
+            args,
+            terms,
+            (ODETerm, AbstractTerm),
+            solver.term_compatible_contr_kwargs,
+        )[0]
     ):
         warnings.warn(
             "Passing `terms=(ODETerm(...), SomeOtherTerm(...))` to "

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -166,7 +166,7 @@ def _term_compatible(
                 vf_type_expected, control_type_expected = term_args
                 try:
                     vf_type = eqx.filter_eval_shape(term.vf, 0.0, yi, args)
-                except ValueError as e:
+                except Exception as e:
                     raise ValueError(f"Error while tracing {term}.vf: " + str(e))
                 vf_type_compatible = eqx.filter_eval_shape(
                     better_isinstance, vf_type, vf_type_expected
@@ -178,7 +178,7 @@ def _term_compatible(
                 # Work around https://github.com/google/jax/issues/21825
                 try:
                     control_type = eqx.filter_eval_shape(contr, 0.0, 0.0)
-                except ValueError as e:
+                except Exception as e:
                     raise ValueError(f"Error while tracing {term}.contr: " + str(e))
                 control_type_compatible = eqx.filter_eval_shape(
                     better_isinstance, control_type, control_type_expected
@@ -192,8 +192,9 @@ def _term_compatible(
     try:
         with jax.numpy_dtype_promotion("standard"):
             jtu.tree_map(_check, term_structure, terms, contr_kwargs, y)
-    except ValueError as e:
+    except Exception as e:
         # ValueError may also arise from mismatched tree structures
+        raise ValueError("Terms are not compatible with solver! " + str(e))
         return False, e
     return True, BaseException()
 

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -193,7 +193,7 @@ def _assert_term_compatible(
             jtu.tree_map(_check, term_structure, terms, contr_kwargs, y)
     except Exception as e:
         # ValueError may also arise from mismatched tree structures
-        raise ValueError("Terms are not compatible with solver! " + str(e))
+        raise ValueError("Terms are not compatible with solver!") from e
 
 
 def _is_subsaveat(x: Any) -> bool:
@@ -1021,6 +1021,9 @@ def diffeqsolve(
                 (ODETerm, AbstractTerm),
                 solver.term_compatible_contr_kwargs,
             )
+        except Exception as _:
+            pass
+        else:
             warnings.warn(
                 "Passing `terms=(ODETerm(...), SomeOtherTerm(...))` to "
                 f"{solver.__class__.__name__} is deprecated in favour of "
@@ -1030,8 +1033,6 @@ def diffeqsolve(
                 stacklevel=2,
             )
             terms = MultiTerm(*terms)
-        except Exception as _:
-            pass
 
     # Error checking
     _assert_term_compatible(

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -1051,7 +1051,7 @@ def diffeqsolve(
     )
 
     if not tc:
-        raise ValueError("Terms are not compatible with solver! " + str(error))
+        raise error
 
     if is_sde(terms):
         if not isinstance(solver, (AbstractItoSolver, AbstractStratonovichSolver)):

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -1040,7 +1040,7 @@ def diffeqsolve(
     )
 
     if not tc:
-        raise error
+        raise ValueError("Terms are not compatible with solver! " + str(error))
 
     if is_sde(terms):
         if not isinstance(solver, (AbstractItoSolver, AbstractStratonovichSolver)):

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -1034,7 +1034,7 @@ def diffeqsolve(
             )
             terms = MultiTerm(*terms)
 
-    # Error checking
+    # Error checking for term compatibility
     _assert_term_compatible(
         y0,
         args,

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -1033,7 +1033,7 @@ def diffeqsolve(
     tc, error = _term_compatible(
         y0, args, terms, solver.term_structure, solver.term_compatible_contr_kwargs
     )
-    print(terms, solver.term_structure)
+
     if not tc:
         raise error
 

--- a/diffrax/_solver/srk.py
+++ b/diffrax/_solver/srk.py
@@ -363,7 +363,11 @@ class AbstractSRK(AbstractSolver[_SolverState]):
         # Now the diffusion related stuff
         # Brownian increment (and space-time Lévy area)
         bm_inc = diffusion.contr(t0, t1, use_levy=True)
-        assert isinstance(bm_inc, self.minimal_levy_area)
+        if not isinstance(bm_inc, self.minimal_levy_area):
+            raise ValueError(
+                f"The brownian increment {bm_inc} does not have the "
+                "minimal Levy Area {self.minimal_levy_area}."
+            )
         w = bm_inc.W
 
         # b looks similar regardless of whether we have additive noise or not

--- a/diffrax/_solver/srk.py
+++ b/diffrax/_solver/srk.py
@@ -366,7 +366,7 @@ class AbstractSRK(AbstractSolver[_SolverState]):
         if not isinstance(bm_inc, self.minimal_levy_area):
             raise ValueError(
                 f"The brownian increment {bm_inc} does not have the "
-                "minimal Levy Area {self.minimal_levy_area}."
+                f"minimal Levy Area {self.minimal_levy_area}."
             )
         w = bm_inc.W
 

--- a/diffrax/_solver/srk.py
+++ b/diffrax/_solver/srk.py
@@ -365,7 +365,7 @@ class AbstractSRK(AbstractSolver[_SolverState]):
         bm_inc = diffusion.contr(t0, t1, use_levy=True)
         if not isinstance(bm_inc, self.minimal_levy_area):
             raise ValueError(
-                f"The brownian increment {bm_inc} does not have the "
+                f"The Brownian increment {bm_inc} does not have the "
                 f"minimal Levy Area {self.minimal_levy_area}."
             )
         w = bm_inc.W

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -627,7 +627,7 @@ def test_term_compatibility():
         compatible_vf, compatible_control
     )
     for term in incompatible_terms:
-        with pytest.raises(ValueError, match=r"`terms` must be a PyTree of"):
+        with pytest.raises(ValueError, match=r"Terms are not compatible with solver! "):
             diffrax.diffeqsolve(term, solver, 0.0, 1.0, 0.1, (jnp.zeros((2, 1)),))
 
     diffrax.diffeqsolve(
@@ -786,5 +786,5 @@ def test_term_compatibility_pytree():
         ):
             if term is compatible_term and y0 is compatible_y0:
                 continue
-            with pytest.raises(ValueError, match=r"`terms` must be a PyTree of"):
+            with pytest.raises(ValueError, match=r"Terms are not compatible with solver! "):
                 diffrax.diffeqsolve(term, solver, 0.0, 1.0, 0.1, y0)

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -627,7 +627,7 @@ def test_term_compatibility():
         compatible_vf, compatible_control
     )
     for term in incompatible_terms:
-        with pytest.raises(ValueError, match=r"Terms are not compatible with solver! "):
+        with pytest.raises(ValueError, match=r"Terms are not compatible with solver!"):
             diffrax.diffeqsolve(term, solver, 0.0, 1.0, 0.1, (jnp.zeros((2, 1)),))
 
     diffrax.diffeqsolve(
@@ -787,6 +787,6 @@ def test_term_compatibility_pytree():
             if term is compatible_term and y0 is compatible_y0:
                 continue
             with pytest.raises(
-                ValueError, match=r"Terms are not compatible with solver! "
+                ValueError, match=r"Terms are not compatible with solver!"
             ):
                 diffrax.diffeqsolve(term, solver, 0.0, 1.0, 0.1, y0)

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -786,5 +786,7 @@ def test_term_compatibility_pytree():
         ):
             if term is compatible_term and y0 is compatible_y0:
                 continue
-            with pytest.raises(ValueError, match=r"Terms are not compatible with solver! "):
+            with pytest.raises(
+                ValueError, match=r"Terms are not compatible with solver! "
+            ):
                 diffrax.diffeqsolve(term, solver, 0.0, 1.0, 0.1, y0)


### PR DESCRIPTION
Previously, the abstract term error, now:

https://github.com/patrick-kidger/diffrax/issues/446: `ValueError: Error while tracing ODETerm(vector_field=<function equations>).vf: matmul input operand 1 must have ndim at least 1, but it has ndim 0` 

https://github.com/patrick-kidger/diffrax/issues/461: `ValueError: The brownian increment BrownianIncrement(dt=f32[], W=f32[5]) does not have the minimal Levy Area <class 'diffrax._custom_types.AbstractSpaceTimeLevyArea'>.`

https://github.com/patrick-kidger/diffrax/issues/474: `ValueError: The brownian increment BrownianIncrement(dt=f32[], W=f32[]) does not have the minimal Levy Area <class 'diffrax._custom_types.AbstractSpaceTimeLevyArea'>.`

Just generally propagating the actual error