### PR TITLE
Parallelize testing

### DIFF
--- a/test/__main__.py
+++ b/test/__main__.py
@@ -12,7 +12,7 @@ flags = " ".join(map(shlex.quote, sys.argv[1:]))
 running_out = 0
 for file in here.iterdir():
     if file.is_file() and file.name.startswith("test"):
-        cmd = f"pytest {file} " + flags
+        cmd = f"pytest -n auto {file} " + flags
         out = subprocess.run(cmd, shell=True).returncode
         running_out = max(running_out, out)
 sys.exit(running_out)

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -12,7 +12,7 @@ flags = " ".join(map(shlex.quote, sys.argv[1:]))
 running_out = 0
 for file in here.iterdir():
     if file.is_file() and file.name.startswith("test"):
-        cmd = f"pytest -n auto {file} " + flags
+        cmd = f"pytest -n 3 {file} " + flags
         out = subprocess.run(cmd, shell=True).returncode
         running_out = max(running_out, out)
 sys.exit(running_out)

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -12,7 +12,7 @@ flags = " ".join(map(shlex.quote, sys.argv[1:]))
 running_out = 0
 for file in here.iterdir():
     if file.is_file() and file.name.startswith("test"):
-        cmd = f"pytest -n 3 {file} " + flags
+        cmd = f"pytest -n 2 {file} " + flags
         out = subprocess.run(cmd, shell=True).returncode
         running_out = max(running_out, out)
 sys.exit(running_out)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,5 +2,6 @@ beartype
 jaxlib
 optax
 pytest
+pytest-xdist
 scipy
 tqdm


### PR DESCRIPTION
90-95 min is benchmark to beat (based on https://github.com/patrick-kidger/diffrax/pull/463, https://github.com/patrick-kidger/diffrax/pull/469, etc). Ideal is 4x since I believe default runner has 4 CPUs, but I don't think that will happen since its run one file at a time (maybe 2x speedup will be good?). No ooms locally, but not sure how much memory the runner has.

Addresses https://github.com/patrick-kidger/diffrax/issues/486