### PR TITLE
Fixes in prep for new release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,4 @@ repos:
     rev: v1.1.350
     hooks:
     - id: pyright
-      additional_dependencies: [equinox, jax, jaxtyping, optax, optimistix, lineax, pytest, typing_extensions]
+      additional_dependencies: [equinox, jax, jaxtyping, optax, optimistix, lineax, pytest, typeguard==2.13.3, typing_extensions]

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -775,27 +775,31 @@ def loop(
                 save_state = _save(tfinal, yfinal, args, subsaveat.fn, save_state)
         return save_state
 
-    def _save_ts(subsaveat: SubSaveAt, save_state: SaveState) -> SaveState:
+    def _save_if_t0_equals_t1(subsaveat: SubSaveAt, save_state: SaveState) -> SaveState:
         if subsaveat.ts is not None:
             out_size = 1 if subsaveat.t0 else 0
             out_size += 1 if subsaveat.t1 and not subsaveat.steps else 0
             out_size += len(subsaveat.ts)
-            ys = jtu.tree_map(
-                lambda y: jnp.stack([y] * out_size),
-                subsaveat.fn(t0, yfinal, args),
-            )
+
+            def _make_ys(out, old_outs):
+                outs = jnp.stack([out] * out_size)
+                if subsaveat.steps:
+                    outs = jnp.concatenate(
+                        [
+                            outs,
+                            jnp.full(
+                                (max_steps,) + out.shape, jnp.inf, dtype=out.dtype
+                            ),
+                        ]
+                    )
+                assert outs.shape == old_outs.shape
+                return outs
+
             ts = jnp.full(out_size, t0)
             if subsaveat.steps:
-                ysteps = jtu.tree_map(
-                    lambda y: jnp.stack([y] * max_steps),
-                    subsaveat.fn(t0, jnp.full_like(yfinal, jnp.inf), args),
-                )
-                ys = jtu.tree_map(
-                    lambda _ys, _ysteps: jnp.concatenate([_ys, _ysteps], axis=0),
-                    ys,
-                    ysteps,
-                )
-                ts = jnp.concatenate((ts, jnp.full(max_steps, jnp.inf)))
+                ts = jnp.concatenate((ts, jnp.full(max_steps, jnp.inf, dtype=ts.dtype)))
+            assert ts.shape == save_state.ts.shape
+            ys = jtu.tree_map(_make_ys, subsaveat.fn(t0, yfinal, args), save_state.ys)
             save_state = SaveState(
                 saveat_ts_index=out_size,
                 ts=ts,
@@ -816,7 +820,7 @@ def loop(
         lambda __save_state: jax.lax.cond(
             t0 == t1,
             lambda _save_state: jtu.tree_map(
-                _save_ts, saveat.subs, _save_state, is_leaf=_is_subsaveat
+                _save_if_t0_equals_t1, saveat.subs, _save_state, is_leaf=_is_subsaveat
             ),
             lambda _save_state: _save_state,
             __save_state,

--- a/diffrax/_local_interpolation.py
+++ b/diffrax/_local_interpolation.py
@@ -110,7 +110,7 @@ class FourthOrderPolynomialInterpolation(AbstractLocalInterpolation):
     ):
         def _calculate(_y0, _y1, _k):
             with jax.numpy_dtype_promotion("standard"):
-                _ymid = _y0 + jnp.tensordot(self.c_mid, _k, axes=1)
+                _ymid = _y0 + jnp.tensordot(self.c_mid, _k, axes=1).astype(_y0.dtype)
             _f0 = _k[0]
             _f1 = _k[-1]
             # TODO: rewrite as matrix-vector product?

--- a/diffrax/_solver/runge_kutta.py
+++ b/diffrax/_solver/runge_kutta.py
@@ -964,7 +964,7 @@ class AbstractRungeKutta(AbstractAdaptiveSolver[_SolverState]):
                         assert implicit_tableau.a_diagonal[0] == 0  # pyright: ignore
                         assert len(set(implicit_tableau.a_diagonal[1:])) == 1  # pyright: ignore
                         jac_stage_index = 1
-                        stage_index = eqxi.nonbatchable(stage_index)
+                    stage_index = eqxi.nonbatchable(stage_index)
                     # These `stop_gradients` are needed to work around the lack of
                     # symbolic zeros in `custom_vjp`s.
                     if eval_fs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diffrax"
-version = "0.6.0"
+version = "0.6.1"
 description = "GPU+autodiff-capable ODE/SDE/CDE solvers written in JAX."
 readme = "README.md"
 requires-python ="~=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/diffrax" }
-dependencies = ["jax>=0.4.28", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard==2.13.3", "equinox>=0.11.2", "lineax>=0.0.5", "optimistix>=0.0.7"]
+dependencies = ["jax>=0.4.28", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard==2.13.3", "equinox>=0.11.10", "lineax>=0.0.5", "optimistix>=0.0.7"]
 
 [build-system]
 requires = ["hatchling"]

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 import diffrax
 import equinox as eqx
 import jax
-import jax.interpreters.ad
+import jax._src.interpreters.ad
 import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
@@ -21,6 +21,7 @@ class _VectorField(eqx.Module):
     diff_arg: float
 
     def __call__(self, t, y, args):
+        del t
         assert y.shape == (2,)
         diff_arg, nondiff_arg = args
         dya = diff_arg * y[0] + nondiff_arg * y[1]
@@ -29,7 +30,7 @@ class _VectorField(eqx.Module):
 
 
 @pytest.mark.slow
-def test_against(getkey):
+def test_against():
     y0 = jnp.array([0.9, 5.4])
     args = (0.1, -1)
     term = diffrax.ODETerm(_VectorField(nondiff_arg=1, diff_arg=-0.1))
@@ -215,6 +216,7 @@ def test_closure_errors():
     @eqx.filter_value_and_grad
     def run(model):
         def f(t, y, args):
+            del t, args
             return model(y)
 
         sol = diffrax.diffeqsolve(
@@ -228,7 +230,7 @@ def test_closure_errors():
         )
         return jnp.sum(cast(Array, sol.ys))
 
-    with pytest.raises(jax.interpreters.ad.CustomVJPException):
+    with pytest.raises(jax._src.interpreters.ad.CustomVJPException):
         run(mlp)
 
 
@@ -239,6 +241,7 @@ def test_closure_fixed():
         model: Callable
 
         def __call__(self, t, y, args):
+            del t, args
             return self.model(y)
 
     @eqx.filter_jit
@@ -307,12 +310,12 @@ def test_implicit():
         model = eqx.apply_updates(model, updates)
         return model, opt_state
 
-    for step in range(100):
+    for _ in range(100):
         model, opt_state = make_step(model, opt_state, target_steady_state)
     assert tree_allclose(model.steady_state, target_steady_state, rtol=1e-2, atol=1e-2)
 
 
-def test_backprop_ts(getkey):
+def test_backprop_ts():
     mlp = eqx.nn.MLP(1, 1, 8, 2, key=jr.PRNGKey(0))
 
     @eqx.filter_jit
@@ -338,14 +341,17 @@ def test_backprop_ts(getkey):
 )
 def test_sde_against(diffusion_fn, getkey):
     def f(t, y, args):
+        del t
         k0, _ = args
         return -k0 * y
 
     def g(t, y, args):
+        del t
         _, k1 = args
         return k1 * y
 
     def g_lx(t, y, args):
+        del t
         _, k1 = args
         return lx.DiagonalLinearOperator(k1 * y)
 

--- a/test/test_global_interpolation.py
+++ b/test/test_global_interpolation.py
@@ -340,7 +340,7 @@ def _test_dense_interpolation(solver, key, t1):
 
 
 @pytest.mark.parametrize("solver", all_ode_solvers + all_split_solvers)
-def test_dense_interpolation(solver, getkey):
+def test_dense_interpolation(solver):
     solver = implicit_tol(solver)
     key = jr.PRNGKey(5678)
     vals, true_vals, derivs, true_derivs = _test_dense_interpolation(solver, key, 1)


### PR DESCRIPTION
- Updates to the t0==t1 case to handle `SubSaveAt(fn=...)` and nonstandard dtypes correctly.
- Fix #532 .
- Fix pre-commit failure due to jaxtyping update.