### PR TITLE
Update deprecated ConcreteArray to core.is_concrete

### DIFF
--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -262,10 +262,17 @@ def _maybe_static(static_x: Optional[ArrayLike], x: ArrayLike) -> ArrayLike:
         return static_x
     elif static_x is None:
         return x
-    elif type(jax.core.get_aval(static_x)) is jax.core.ConcreteArray:
-        return static_x
     else:
-        return x
+        if jax.__version_info__ >= (0, 4, 36):
+            if jax.core.is_concrete(static_x):
+                return static_x
+            else:
+                return x
+        else:
+            if type(jax.core.get_aval(static_x)) is jax.core.ConcreteArray:
+                return static_x
+            else:
+                return x
 
 
 _PRINT_STATIC = False  # used in tests

--- a/diffrax/_misc.py
+++ b/diffrax/_misc.py
@@ -146,10 +146,11 @@ def static_select(pred: BoolScalarLike, a: ArrayLike, b: ArrayLike) -> ArrayLike
     # predicate is statically known.
     # This in turn allows us to perform some trace-time optimisations that XLA isn't
     # smart enough to do on its own.
-    if (
-        type(pred) is not bool
-        and type(jax.core.get_aval(pred)) is jax.core.ConcreteArray
-    ):
+    if jax.__version_info__ >= (0, 4, 36):
+        is_conrete = jax.core.is_concrete(pred)
+    else:
+        is_conrete = type(jax.core.get_aval(pred)) is jax.core.ConcreteArray
+    if type(pred) is not bool and is_conrete:
         with jax.ensure_compile_time_eval():
             pred = pred.item()
     if pred is True:


### PR DESCRIPTION
Hello :wave:

jax.core.ConcreteArray has been deprecated and removed

This is causing a few issues in diffrax

I made a quick fix inspired by [JAX own fixes ](https://github.com/jax-ml/jax/commit/48f24b6acb9fe67dfe227ff3349787b4045c09ff#diff-84dca1c418fbdddfa3653dffbad8ebe91310c4ef5c1db44b356e48af5ab3fc76L2190)

Thanks