### PR TITLE
Add a forward-mode adjoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ site/
 .all_objects.cache
 .pymon
 .idea/
+.venv

--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -4,6 +4,7 @@ from ._adjoint import (
     AbstractAdjoint as AbstractAdjoint,
     BacksolveAdjoint as BacksolveAdjoint,
     DirectAdjoint as DirectAdjoint,
+    ForwardAdjoint as ForwardAdjoint,
     ImplicitAdjoint as ImplicitAdjoint,
     RecursiveCheckpointAdjoint as RecursiveCheckpointAdjoint,
 )

--- a/docs/api/adjoints.md
+++ b/docs/api/adjoints.md
@@ -44,6 +44,10 @@ Of the following options, [`diffrax.RecursiveCheckpointAdjoint`][] and [`diffrax
     selection:
         members: false
 
+::: diffrax.ForwardAdjoint
+    selection: 
+        members: false
+
 ---
 
 ::: diffrax.adjoint_rms_seminorm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ mkdocs==1.3.0            # Main documentation generator.
 mkdocs-material==7.3.6   # Theme
 pymdown-extensions==9.4  # Markdown extensions e.g. to handle LaTeX.
 mkdocstrings==0.17.0     # Autogenerate documentation from docstrings.
+mkdocs-autorefs==1.0.1   # Automatically generate references to other pages.
 mknotebooks==0.7.1       # Turn Jupyter Lab notebooks into webpages.
 pytkdocs_tweaks==0.0.8   # Tweaks mkdocstrings to improve various aspects
 mkdocs_include_exclude_files==0.0.1  # Allow for customising which files get included


### PR DESCRIPTION
Hi Patrick, 

do you remember the forward-mode adjoint [you wrote for me](https://github.com/patrick-kidger/optimistix/pull/51#issuecomment-2105948574) all those many months ago? 

I've been wanting to make this useful to others for a long time, here it is! I have some questions: 

1. I did not manage to write a test that mimics the behaviour of `jax.grad(..., allow_int=True)`. `jacfwd` and `jax.linearize` do not support integer inputs, writing some custom thing that computes a JVP with respect to "unit pytrees" with mixed types and non-arrays is... a pain.
This seems like an exceedingly rare use case given the difficulties, but maybe we should document somewhere that this option is not, in fact, available. (Or leave it be, since diffrax does not differ from jax in this respect.)
2. I wrote a two-liner documentation thing - and frankly, I don't think I understand what magic is actually happening well enough to explain more! 
3. Anything else? Does forward-mode automatic differentiation have edge cases that we should test explicitly?

To serve documentation, I needed to make the version of mkdocs-autorefs explicit (to the second-to-last release or so), so I added that too. This also came up for optimistix a [while ago](https://github.com/patrick-kidger/optimistix/pull/91).

Lastly, this is rebased on dev as of now - but I can imagine that your weekend was quite busy following Friday's release, so if you'd like to postpone this, I'm not in a rush! I will mark this as a draft, due to the questions above.