### PR TITLE
Forward mode "adjoint" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ site/
 .all_objects.cache
 .pymon
 .idea/
+.venv/

--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -4,6 +4,7 @@ from ._adjoint import (
     AbstractAdjoint as AbstractAdjoint,
     BacksolveAdjoint as BacksolveAdjoint,
     DirectAdjoint as DirectAdjoint,
+    ForwardAdjoint as ForwardAdjoint,
     ImplicitAdjoint as ImplicitAdjoint,
     RecursiveCheckpointAdjoint as RecursiveCheckpointAdjoint,
 )

--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -4,7 +4,7 @@ from ._adjoint import (
     AbstractAdjoint as AbstractAdjoint,
     BacksolveAdjoint as BacksolveAdjoint,
     DirectAdjoint as DirectAdjoint,
-    ForwardAdjoint as ForwardAdjoint,
+    ForwardMode as ForwardMode,
     ImplicitAdjoint as ImplicitAdjoint,
     RecursiveCheckpointAdjoint as RecursiveCheckpointAdjoint,
 )

--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -184,7 +184,9 @@ class RecursiveCheckpointAdjoint(AbstractAdjoint):
     !!! info
 
         Note that this cannot be forward-mode autodifferentiated. (E.g. using
-        `jax.jvp`.) Try using [`diffrax.DirectAdjoint`][] if that is something you need.
+        `jax.jvp`.) Try using [`diffrax.DirectAdjoint`][] if you need both forward-mode
+        and reverse-mode autodifferentiation, and [`diffrax.ForwardMode`][] if you need
+        only forward-mode autodifferentiation.
 
     ??? cite "References"
 
@@ -333,6 +335,8 @@ class DirectAdjoint(AbstractAdjoint):
 
     So unless you need forward-mode autodifferentiation then
     [`diffrax.RecursiveCheckpointAdjoint`][] should be preferred.
+    If you need only forward-mode autodifferentiation, then [`diffrax.ForwardMode`][] is
+    more efficient.
     """
 
     def loop(
@@ -855,11 +859,13 @@ class BacksolveAdjoint(AbstractAdjoint):
 
 
 class ForwardMode(AbstractAdjoint):
-    """Differentiate through a differential equation solve during the forward pass.
-    (So it is not really an adjoint - it is a different way of quantifying the
-    sensitivity of the output to the input.)
+    """Supports forward-mode automatic differentiation through a differential equation
+    solve. This works by propagating the derivatives during the forward-pass - that is,
+    during the ODE solve, instead of solving the adjoint equations afterwards.
+    (So this is really a different way of quantifying the sensitivity of the output to
+    the input, even if its interface is that of an adjoint for convenience.)
 
-    ForwardMode is useful when we have many more outputs than inputs to a function - for
+    This is useful when we have many more outputs than inputs to a function - for
     instance during parameter inference for ODE models with least-squares solvers such
     as `optimistix.Levenberg-Marquardt`, that operate on the residuals.
     """

--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -854,12 +854,14 @@ class BacksolveAdjoint(AbstractAdjoint):
         return final_state, aux_stats
 
 
-class ForwardAdjoint(AbstractAdjoint):
+class ForwardMode(AbstractAdjoint):
     """Differentiate through a differential equation solve during the forward pass.
+    (So it is not really an adjoint - it is a different way of quantifying the
+    sensitivity of the output to the input.)
 
-    This is a useful adjoint to use whenever we have many more outputs than inputs to a
-    function - for instance during parameter inference for ODE models with least-squares
-    based solvers such as `optimistix.Levenberg-Marquardt`.
+    ForwardMode is useful when we have many more outputs than inputs to a function - for
+    instance during parameter inference for ODE models with least-squares solvers such
+    as `optimistix.Levenberg-Marquardt`, that operate on the residuals.
     """
 
     def loop(

--- a/docs/api/adjoints.md
+++ b/docs/api/adjoints.md
@@ -44,7 +44,7 @@ Of the following options, [`diffrax.RecursiveCheckpointAdjoint`][] and [`diffrax
     selection:
         members: false
 
-::: diffrax.ForwardAdjoint
+::: diffrax.ForwardMode
     selection: 
         members: false
 

--- a/docs/api/adjoints.md
+++ b/docs/api/adjoints.md
@@ -44,6 +44,10 @@ Of the following options, [`diffrax.RecursiveCheckpointAdjoint`][] and [`diffrax
     selection:
         members: false
 
+::: diffrax.ForwardAdjoint
+    selection: 
+        members: false
+
 ---
 
 ::: diffrax.adjoint_rms_seminorm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ mkdocs==1.3.0            # Main documentation generator.
 mkdocs-material==7.3.6   # Theme
 pymdown-extensions==9.4  # Markdown extensions e.g. to handle LaTeX.
 mkdocstrings==0.17.0     # Autogenerate documentation from docstrings.
+mkdocs-autorefs==1.0.1   # Automatically generate references to other pages.
 mknotebooks==0.7.1       # Turn Jupyter Lab notebooks into webpages.
 pytkdocs_tweaks==0.0.8   # Tweaks mkdocstrings to improve various aspects
 mkdocs_include_exclude_files==0.0.1  # Allow for customising which files get included

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,6 @@ mkdocs==1.3.0            # Main documentation generator.
 mkdocs-material==7.3.6   # Theme
 pymdown-extensions==9.4  # Markdown extensions e.g. to handle LaTeX.
 mkdocstrings==0.17.0     # Autogenerate documentation from docstrings.
-mkdocs-autorefs==1.0.1   # Automatically generate references to other pages.
 mknotebooks==0.7.1       # Turn Jupyter Lab notebooks into webpages.
 pytkdocs_tweaks==0.0.8   # Tweaks mkdocstrings to improve various aspects
 mkdocs_include_exclude_files==0.0.1  # Allow for customising which files get included


### PR DESCRIPTION
Here you go! This is the pragmatic solution, without support or test coverage for integer inputs and only a small comment explicating that forward mode is not really an adjoint, even though its diffrax interface is that of an adjoint.

Changes with respect to the last PR: 

- renamed to `ForwardMode` everywhere
- add a sentence to the docstring that explains that this is not really an adjoint, but keep inheriting from `AbstractAdjoint`
- remove stub for "forward gradient with int" from `test_adjoint.py` and explain that since JAX does not offer this option, we're not writing our own workaround to test it either

_On the last point: if I understood this correctly, then supporting this would entail writing a gradient-computation directly from a JVP with custom "unit pytrees". This is somewhat annoying for mixed array and non-array types. 
I'm happy to try again if computing gradients with respect to integer elements of a PyTree is an expected use case (maybe arising from composed/layered transformations of a solve) that requires test coverage._

Earlier comments [here](https://github.com/patrick-kidger/diffrax/pull/536#pullrequestreview-2488189344). 

(This is now rebased on main.)