### PR TITLE
Import Jaxpr and ClosedJaxpr from jax.exend

### DIFF
--- a/diffrax/_misc.py
+++ b/diffrax/_misc.py
@@ -148,7 +148,7 @@ def static_select(pred: BoolScalarLike, a: ArrayLike, b: ArrayLike) -> ArrayLike
     # This in turn allows us to perform some trace-time optimisations that XLA isn't
     # smart enough to do on its own.
     if isinstance(pred, (np.ndarray, np.generic)) and pred.shape == ():
-        pred = pred.item()
+        pred = cast(BoolScalarLike, pred.item())
     if pred is True:
         return a
     elif pred is False:

--- a/diffrax/_progress_meter.py
+++ b/diffrax/_progress_meter.py
@@ -123,8 +123,9 @@ class TextProgressMeter(AbstractProgressMeter):
         if eqx.is_array(progress):
             # May not be an array when called with `JAX_DISABLE_JIT=1`
             progress = cast(Union[Array, np.ndarray], progress)
-            progress = progress.item()
-        progress = cast(float, progress)
+            progress = cast(float, progress.item())
+        else:
+            progress = cast(float, progress)
         bar[0] = progress
         print(f"{100 * progress:.2f}%")
 

--- a/diffrax/_solver/runge_kutta.py
+++ b/diffrax/_solver/runge_kutta.py
@@ -17,7 +17,7 @@ from typing_extensions import TypeAlias
 import equinox as eqx
 import equinox.internal as eqxi
 import jax
-import jax.core
+import jax.extend as jex
 import jax.lax as lax
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -315,7 +315,7 @@ def _filter_stop_gradient(x):
 
 
 def _is_jaxpr(x):
-    return isinstance(x, (jax.core.Jaxpr, jax.core.ClosedJaxpr))
+    return isinstance(x, (jex.core.Jaxpr, jex.core.ClosedJaxpr))
 
 
 def _filter_maybe_cond(pred, branch, value):


### PR DESCRIPTION
`jax.core.Jaxpr` and `jax.core.ClosedJaxpr` will issue deprecation warnings starting in the next JAX release (0.4.38). They have been available from `jax.extend.core` since JAX v0.4.27, so given that diffrax requires `jax>=0.4.28`, the new import paths can be used unconditionally.