### PR TITLE
Improves error messages for mismatched terms.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,4 @@ repos:
     rev: v1.1.350
     hooks:
     - id: pyright
-      additional_dependencies: [equinox, jax, jaxtyping, optax, optimistix, lineax, pytest, typeguard==2.13.3, typing_extensions]
+      additional_dependencies: [equinox, jax, jaxtyping, optax, optimistix, lineax, pytest, typeguard==2.13.3, typing_extensions, wadler_lindig]

--- a/diffrax/_custom_types.py
+++ b/diffrax/_custom_types.py
@@ -112,6 +112,14 @@ class SpaceTimeTimeLevyArea(AbstractSpaceTimeTimeLevyArea):
     K: BM
 
 
+AbstractBrownianIncrement.__module__ = "diffrax"
+AbstractSpaceTimeLevyArea.__module__ = "diffrax"
+AbstractSpaceTimeTimeLevyArea.__module__ = "diffrax"
+BrownianIncrement.__module__ = "diffrax"
+SpaceTimeLevyArea.__module__ = "diffrax"
+SpaceTimeTimeLevyArea.__module__ = "diffrax"
+
+
 def levy_tree_transpose(
     tree_shape, tree: PyTree[AbstractBrownianIncrement]
 ) -> AbstractBrownianIncrement:

--- a/diffrax/_term.py
+++ b/diffrax/_term.py
@@ -981,3 +981,12 @@ class UnderdampedLangevinDriftTerm(AbstractTerm):
         self, vf: UnderdampedLangevinTuple, control: RealScalarLike
     ) -> UnderdampedLangevinTuple:
         return jtu.tree_map(lambda _vf: control * _vf, vf)
+
+
+AbstractTerm.__module__ = "diffrax"
+ODETerm.__module__ = "diffrax"
+ControlTerm.__module__ = "diffrax"
+WeaklyDiagonalControlTerm.__module__ = "diffrax"
+MultiTerm.__module__ = "diffrax"
+UnderdampedLangevinDriftTerm.__module__ = "diffrax"
+UnderdampedLangevinDiffusionTerm.__module__ = "diffrax"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/diffrax" }
-dependencies = ["jax>=0.4.38", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard==2.13.3", "equinox>=0.11.10", "lineax>=0.0.5", "optimistix>=0.0.10"]
+dependencies = ["jax>=0.4.38", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard==2.13.3", "equinox>=0.11.10", "lineax>=0.0.5", "optimistix>=0.0.10", "wadler_lindig>=0.1.1"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Basically, I made a mistake whilst writing #561, and got annoyed that the error messages weren't helping me that much. (The way all true progress is made.)

Serendipitously, this can also use the new `wadler_lindig` library for pretty-printing complicated types.