### PR TITLE
It might be possible to remove the typeguard dependency?

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _From a technical point of view, the internal structure of the library is pretty
 pip install diffrax
 ```
 
-Requires Python 3.9+, JAX 0.4.13+, and [Equinox](https://github.com/patrick-kidger/equinox) 0.10.11+.
+Requires Python 3.10+.
 
 ## Documentation
 

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -198,7 +198,7 @@ def _assert_term_compatible(
     try:
         with jax.numpy_dtype_promotion("standard"):
             jtu.tree_map(_check, term_structure, terms, contr_kwargs, y)
-    except Exception as e:
+    except ValueError as e:
         # ValueError may also arise from mismatched tree structures
         pretty_term = wl.pformat(terms)
         pretty_expected = wl.pformat(term_structure)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ _From a technical point of view, the internal structure of the library is pretty
 pip install diffrax
 ```
 
-Requires Python 3.9+, JAX 0.4.13+, and [Equinox](https://github.com/patrick-kidger/equinox) 0.10.11+.
+Requires Python 3.10+.
 
 ## Quick example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "diffrax"
 version = "0.6.2"
 description = "GPU+autodiff-capable ODE/SDE/CDE solvers written in JAX."
 readme = "README.md"
-requires-python =">=3.9,<4.0"
+requires-python =">=3.10,<4.0"
 license = {file = "LICENSE"}
 authors = [
   {name = "Patrick Kidger", email = "contact@kidger.site"},


### PR DESCRIPTION
I'm not sure this is actually necessary in any real-world use-cases. Running the tests here as a proxy for that.