### PR TITLE
AbstractReversibleSolver + ReversibleAdjoint

### DIFF
--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -7,6 +7,7 @@ from ._adjoint import (
     ForwardMode as ForwardMode,
     ImplicitAdjoint as ImplicitAdjoint,
     RecursiveCheckpointAdjoint as RecursiveCheckpointAdjoint,
+    ReversibleAdjoint as ReversibleAdjoint,
 )
 from ._autocitation import citation as citation, citation_rules as citation_rules
 from ._brownian import (

--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -1144,20 +1144,6 @@ class ReversibleAdjoint(AbstractAdjoint):
                 "`adjoint=ReversibleAdjoint()` does not support `UnsafeBrownianPath`. "
                 "Consider using `VirtualBrownianTree` instead."
             )
-        if is_sde(terms):
-            if isinstance(solver, AbstractItoSolver):
-                raise NotImplementedError(
-                    f"`{solver.__class__.__name__}` converges to the Itô solution. "
-                    "However `ReversibleAdjoint` currently only supports Stratonovich "
-                    "SDEs."
-                )
-            elif not isinstance(solver, AbstractStratonovichSolver):
-                warnings.warn(
-                    f"{solver.__class__.__name__} is not marked as converging to "
-                    "either the Itô or the Stratonovich solution. Note that "
-                    "`ReversibleAdjoint` will only produce the correct solution for "
-                    "Stratonovich SDEs."
-                )
 
         y = init_state.y
         init_state = eqx.tree_at(lambda s: s.y, init_state, object())

--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -1080,7 +1080,7 @@ def _loop_reversible_bwd(
         grad_terms,
     )
 
-    state = eqxi.while_loop(cond_fun, grad_step, state, kind="lax")
+    state = jax.lax.while_loop(cond_fun, grad_step, state)
     _, _, y0, _, grad_y0, grad_state, grad_args, grad_terms = state
 
     # Pull solver_state gradients back onto y0, args, terms.

--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -1121,22 +1121,17 @@ class ReversibleAdjoint(AbstractAdjoint):
                 "`max_steps=None` is incompatible with `ReversibleAdjoint`."
             )
 
-        if jtu.tree_structure(saveat.subs, is_leaf=_is_subsaveat) != jtu.tree_structure(
-            0
+        if (
+            jtu.tree_structure(saveat.subs, is_leaf=_is_subsaveat)
+            != jtu.tree_structure(0)
+            or saveat.dense
+            or saveat.subs.steps
+            or (saveat.subs.fn is not save_y)
         ):
-            raise NotImplementedError(
-                "Cannot use `adjoint=ReversibleAdjoint()` with `SaveAt(subs=...)`."
-            )
-
-        if saveat.dense or saveat.subs.steps:
-            raise NotImplementedError(
-                "Cannot use `adjoint=ReversibleAdjoint()` with "
-                "`saveat=SaveAt(steps=True)` or saveat=SaveAt(dense=True)`."
-            )
-
-        if saveat.subs.fn is not save_y:
-            raise NotImplementedError(
-                "Cannot use `adjoint=ReversibleAdjoint()` with `saveat=SaveAt(fn=...)`."
+            raise ValueError(
+                """`ReversibleAdjoint` is only compatible with the following `SaveAt` 
+                properties: `t0`, `t1`, `ts`, `fn=save_y` (default).
+                """
             )
 
         if event is not None:

--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -1013,7 +1013,7 @@ def _loop_reversible_bwd(
         t1 = ts[ts_index]
         t0 = ts[ts_index - 1]
 
-        y0, _, dense_info, solver_state, _ = solver.backward_step(
+        y0, dense_info, solver_state = solver.backward_step(
             terms, t0, t1, y1, args, solver_state, False
         )
 

--- a/diffrax/_solver/base.py
+++ b/diffrax/_solver/base.py
@@ -348,3 +348,60 @@ HalfSolver.__init__.__doc__ = """**Arguments:**
 
 - `solver`: The solver to wrap.
 """
+
+
+class AbstractReversibleSolver(AbstractSolver[_SolverState]):
+    """Indicates that this is a reversible differential equation solver. This means
+    that the state at `t0` can be reconstructed (in closed form) from the state at `t1`.
+
+    The reconstruction must be implemented by
+    [`diffrax.AbstractReversibleSolver.backward_step`][].
+
+    This solver can be combined with `adjoint=diffrax.ReversibleAdjoint` for exact
+    gradient backpropagation in $O(n)$ time and $O(1)$ memory, for $n$ time steps.
+    """
+
+    @abc.abstractmethod
+    def backward_step(
+        self,
+        terms: PyTree[AbstractTerm],
+        t0: RealScalarLike,
+        t1: RealScalarLike,
+        y1: Y,
+        args: Args,
+        solver_state: _SolverState,
+        made_jump: BoolScalarLike,
+    ) -> tuple[Y, Optional[Y], DenseInfo, _SolverState, RESULTS]:
+        """
+        Make a single backward step with the reversible solver.
+
+        Each step is made over the specified interval $[t_1, t_0]$.
+
+        **Arguments:**
+
+        - `terms`: The PyTree of terms representing the vector fields and controls.
+        - `t0`: The end of the interval that the backward step is made over.
+        - `t1`: The start of the interval that the backward step is made over.
+        - `y1`: The current value of the solution at `t1`.
+        - `args`: Any extra arguments passed to the vector field.
+        - `solver_state`: Any evolving state for the solver itself, at `t1`.
+        - `made_jump`: Whether there was a discontinuity in the vector field at `t1`.
+            Some solvers (notably FSAL Runge--Kutta solvers) usually assume that there
+            are no jumps and for efficiency re-use information between steps; this
+            indicates that a jump has just occurred and this assumption is not true.
+
+        **Returns:**
+
+        A tuple of several objects:
+
+        - The value of the solution at `t0`.
+        - A local error estimate made during the step. (Used by adaptive step size
+            controllers to change the step size.) May be `None` if no estimate was
+            made.
+        - Some dictionary of information that is passed to the solver's interpolation
+            routine to calculate dense output. Note that this is assumed to be the same
+            information returned on the forward step.
+        - The value of the solver state at `t1`.
+        - An integer (corresponding to `diffrax.RESULTS`) indicating whether the step
+            happened successfully, or if (unusually) it failed for some reason.
+        """

--- a/diffrax/_solver/base.py
+++ b/diffrax/_solver/base.py
@@ -371,7 +371,7 @@ class AbstractReversibleSolver(AbstractSolver[_SolverState]):
         args: Args,
         solver_state: _SolverState,
         made_jump: BoolScalarLike,
-    ) -> tuple[Y, Optional[Y], DenseInfo, _SolverState, RESULTS]:
+    ) -> tuple[Y, DenseInfo, _SolverState]:
         """
         Make a single backward step with the reversible solver.
 
@@ -392,16 +392,11 @@ class AbstractReversibleSolver(AbstractSolver[_SolverState]):
 
         **Returns:**
 
-        A tuple of several objects:
+        A tuple of three objects:
 
         - The value of the solution at `t0`.
-        - A local error estimate made during the step. (Used by adaptive step size
-            controllers to change the step size.) May be `None` if no estimate was
-            made.
         - Some dictionary of information that is passed to the solver's interpolation
             routine to calculate dense output. Note that this is assumed to be the same
             information returned on the forward step.
         - The value of the solver state at `t1`.
-        - An integer (corresponding to `diffrax.RESULTS`) indicating whether the step
-            happened successfully, or if (unusually) it failed for some reason.
         """

--- a/diffrax/_solver/leapfrog_midpoint.py
+++ b/diffrax/_solver/leapfrog_midpoint.py
@@ -101,7 +101,7 @@ class LeapfrogMidpoint(AbstractReversibleSolver):
         args: Args,
         solver_state: _SolverState,
         made_jump: BoolScalarLike,
-    ) -> tuple[Y, _ErrorEstimate, DenseInfo, _SolverState, RESULTS]:
+    ) -> tuple[Y, DenseInfo, _SolverState]:
         del made_jump
         t0, y0, dt = solver_state
         tm1 = t0 - dt
@@ -114,7 +114,7 @@ class LeapfrogMidpoint(AbstractReversibleSolver):
         solver_state = jax.lax.cond(
             tm1 > 0, lambda _: (tm1, ym1, dt), lambda _: (t0, y0, dt), None
         )
-        return y0, None, dense_info, solver_state, RESULTS.successful
+        return y0, dense_info, solver_state
 
     def func(self, terms: AbstractTerm, t0: RealScalarLike, y0: Y, args: Args) -> VF:
         return terms.vf(t0, y0, args)

--- a/diffrax/_solver/leapfrog_midpoint.py
+++ b/diffrax/_solver/leapfrog_midpoint.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import ClassVar
 from typing_extensions import TypeAlias
 
+import jax
 from equinox.internal import ω
 from jaxtyping import PyTree
 
@@ -9,15 +10,15 @@ from .._custom_types import Args, BoolScalarLike, DenseInfo, RealScalarLike, VF,
 from .._local_interpolation import LocalLinearInterpolation
 from .._solution import RESULTS
 from .._term import AbstractTerm
-from .base import AbstractSolver
+from .base import AbstractReversibleSolver
 
 
 _ErrorEstimate: TypeAlias = None
-_SolverState: TypeAlias = tuple[RealScalarLike, PyTree]
+_SolverState: TypeAlias = tuple[RealScalarLike, PyTree, RealScalarLike]
 
 
 # TODO: support arbitrary linear multistep methods
-class LeapfrogMidpoint(AbstractSolver):
+class LeapfrogMidpoint(AbstractReversibleSolver):
     r"""Leapfrog/midpoint method.
 
     2nd order linear multistep method. Uses 1st order local linear interpolation for
@@ -28,6 +29,12 @@ class LeapfrogMidpoint(AbstractSolver):
     many other "leapfrog methods" (there are several), or with the "midpoint method"
     (which is usually taken to refer to the explicit Runge--Kutta method
     [`diffrax.Midpoint`][]).
+
+    !!! note
+        This solver is algebraically reversible, meaning that the state at `t0` can be
+        reconstructed (in closed form) from the state at `t1`. This allows exact
+        gradient backpropagation in $O(n)$ time and $O(1)$ memory when using
+        [`diffrax.ReversibleAdjoint`][].
 
     ??? cite "Reference"
 
@@ -60,9 +67,12 @@ class LeapfrogMidpoint(AbstractSolver):
         y0: Y,
         args: Args,
     ) -> _SolverState:
-        del terms, t1, args
+        # We pre-compute the step size to avoid numerical instability during the
+        # backward_step. This is okay (albeit slightly ugly) as `LeapfrogMidpoint` can't
+        # be used with adaptive step sizes.
+        dt = t1 - t0
         # Corresponds to making an explicit Euler step on the first step.
-        return t0, y0
+        return t0, y0, dt
 
     def step(
         self,
@@ -75,12 +85,36 @@ class LeapfrogMidpoint(AbstractSolver):
         made_jump: BoolScalarLike,
     ) -> tuple[Y, _ErrorEstimate, DenseInfo, _SolverState, RESULTS]:
         del made_jump
-        tm1, ym1 = solver_state
+        tm1, ym1, dt = solver_state
         control = terms.contr(tm1, t1)
         y1 = (ym1**ω + terms.vf_prod(t0, y0, args, control) ** ω).ω
         dense_info = dict(y0=y0, y1=y1)
-        solver_state = (t0, y0)
+        solver_state = (t0, y0, dt)
         return y1, None, dense_info, solver_state, RESULTS.successful
+
+    def backward_step(
+        self,
+        terms: AbstractTerm,
+        t0: RealScalarLike,
+        t1: RealScalarLike,
+        y1: Y,
+        args: Args,
+        solver_state: _SolverState,
+        made_jump: BoolScalarLike,
+    ) -> tuple[Y, _ErrorEstimate, DenseInfo, _SolverState, RESULTS]:
+        del made_jump
+        t0, y0, dt = solver_state
+        tm1 = t0 - dt
+        control = terms.contr(tm1, t1)
+        ym1 = (y1**ω - terms.vf_prod(t0, y0, args, control) ** ω).ω
+        dense_info = dict(y0=y0, y1=y1)
+        # On the last step we need to make sure our solver state is correct
+        # (i.e. the state used on the forward). Otherwise, in `ReversibleAdjoint`,
+        # we would take a local forward step from an incorrect `solver_state`.
+        solver_state = jax.lax.cond(
+            tm1 > 0, lambda _: (tm1, ym1, dt), lambda _: (t0, y0, dt), None
+        )
+        return y0, None, dense_info, solver_state, RESULTS.successful
 
     def func(self, terms: AbstractTerm, t0: RealScalarLike, y0: Y, args: Args) -> VF:
         return terms.vf(t0, y0, args)

--- a/diffrax/_solver/reversible_heun.py
+++ b/diffrax/_solver/reversible_heun.py
@@ -104,7 +104,7 @@ class ReversibleHeun(
         args: Args,
         solver_state: _SolverState,
         made_jump: BoolScalarLike,
-    ) -> tuple[Y, Y, DenseInfo, _SolverState, RESULTS]:
+    ) -> tuple[Y, DenseInfo, _SolverState]:
         yhat1, vf1 = solver_state
 
         control = terms.contr(t0, t1)
@@ -114,7 +114,7 @@ class ReversibleHeun(
 
         dense_info = dict(y0=y0, y1=y1)
         solver_state = (yhat0, vf0)
-        return y0, None, dense_info, solver_state, RESULTS.successful
+        return y0, dense_info, solver_state
 
     def func(self, terms: AbstractTerm, t0: RealScalarLike, y0: Y, args: Args) -> VF:
         return terms.vf(t0, y0, args)

--- a/diffrax/_solver/semi_implicit_euler.py
+++ b/diffrax/_solver/semi_implicit_euler.py
@@ -83,7 +83,7 @@ class SemiImplicitEuler(AbstractReversibleSolver):
         args: Args,
         solver_state: _SolverState,
         made_jump: BoolScalarLike,
-    ) -> tuple[tuple[Ya, Yb], _ErrorEstimate, DenseInfo, _SolverState, RESULTS]:
+    ) -> tuple[tuple[Ya, Yb], DenseInfo, _SolverState]:
         del solver_state, made_jump
 
         term_1, term_2 = terms
@@ -96,7 +96,7 @@ class SemiImplicitEuler(AbstractReversibleSolver):
 
         y0 = (y0_1, y0_2)
         dense_info = dict(y0=y0, y1=y1)
-        return y0, None, dense_info, None, RESULTS.successful
+        return y0, dense_info, None
 
     def func(
         self,

--- a/test/test_reversible.py
+++ b/test/test_reversible.py
@@ -1,0 +1,162 @@
+from typing import cast
+
+import diffrax
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jaxtyping import Array
+
+from .helpers import tree_allclose
+
+
+class VectorField(eqx.Module):
+    mlp: eqx.nn.MLP
+
+    def __init__(self, in_size, out_size, width_size, depth, key):
+        self.mlp = eqx.nn.MLP(in_size, out_size, width_size, depth, key=key)
+
+    def __call__(self, t, y, args):
+        return args * self.mlp(y)
+
+
+@eqx.filter_value_and_grad
+def _loss(y0__args__term, solver, saveat, adjoint, stepsize_controller, dual_y0):
+    y0, args, term = y0__args__term
+
+    sol = diffrax.diffeqsolve(
+        term,
+        solver,
+        t0=0,
+        t1=5,
+        dt0=0.01,
+        y0=y0,
+        args=args,
+        saveat=saveat,
+        max_steps=4096,
+        adjoint=adjoint,
+        stepsize_controller=stepsize_controller,
+    )
+    if dual_y0:
+        y1 = sol.ys[0]  # pyright: ignore
+    else:
+        y1 = sol.ys
+    return jnp.sum(cast(Array, y1))
+
+
+def _compare_grads(y0__args__term, solver, saveat, stepsize_controller, dual_y0):
+    loss, grads_base = _loss(
+        y0__args__term,
+        solver,
+        saveat,
+        adjoint=diffrax.RecursiveCheckpointAdjoint(),
+        stepsize_controller=stepsize_controller,
+        dual_y0=dual_y0,
+    )
+    loss, grads_reversible = _loss(
+        y0__args__term,
+        solver,
+        saveat,
+        adjoint=diffrax.ReversibleAdjoint(),
+        stepsize_controller=stepsize_controller,
+        dual_y0=dual_y0,
+    )
+    assert tree_allclose(grads_base, grads_reversible, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "saveat",
+    [
+        diffrax.SaveAt(t0=True, t1=True),
+        diffrax.SaveAt(t0=True, ts=jnp.linspace(0, 5, 10), t1=True),
+    ],
+)
+def test_semi_implicit_euler(saveat):
+    n = 10
+    y0 = jnp.linspace(1, 10, num=n)
+    key = jr.PRNGKey(10)
+    fkey, gkey = jr.split(key, 2)
+    f = VectorField(n, n, n, depth=4, key=fkey)
+    g = VectorField(n, n, n, depth=4, key=gkey)
+    terms = (diffrax.ODETerm(f), diffrax.ODETerm(g))
+    y0 = (y0, y0)
+    args = jnp.linspace(0, 1, n)
+    solver = diffrax.SemiImplicitEuler()
+    stepsize_controller = diffrax.ConstantStepSize()
+
+    _compare_grads((y0, args, terms), solver, saveat, stepsize_controller, dual_y0=True)
+
+
+@pytest.mark.parametrize(
+    "stepsize_controller",
+    [diffrax.ConstantStepSize(), diffrax.PIDController(rtol=1e-8, atol=1e-8)],
+)
+@pytest.mark.parametrize(
+    "saveat",
+    [
+        diffrax.SaveAt(t0=True, t1=True),
+        diffrax.SaveAt(t0=True, ts=jnp.linspace(0, 5, 10), t1=True),
+    ],
+)
+def test_reversible_heun_ode(stepsize_controller, saveat):
+    n = 10
+    y0 = jnp.linspace(1, 10, num=n)
+    key = jr.PRNGKey(10)
+    f = VectorField(n, n, n, depth=4, key=key)
+    terms = diffrax.ODETerm(f)
+    y0 = y0
+    args = jnp.linspace(0, 1, n)
+    solver = diffrax.ReversibleHeun()
+
+    _compare_grads(
+        (y0, args, terms), solver, saveat, stepsize_controller, dual_y0=False
+    )
+
+
+@pytest.mark.parametrize(
+    "saveat",
+    [
+        diffrax.SaveAt(t0=True, t1=True),
+        diffrax.SaveAt(t0=True, ts=jnp.linspace(0, 5, 10), t1=True),
+    ],
+)
+def test_reversible_heun_sde(saveat):
+    n = 10
+    y0 = jnp.linspace(1, 10, num=n)
+    key = jr.PRNGKey(10)
+    fkey, Wkey = jr.split(key, 2)
+    f = VectorField(n, n, n, depth=4, key=fkey)
+    g = lambda t, y, args: jnp.ones((n,))
+    W = diffrax.VirtualBrownianTree(t0=0, t1=5, tol=1e-3, shape=(n,), key=Wkey)
+    terms = diffrax.MultiTerm(diffrax.ODETerm(f), diffrax.ControlTerm(g, W))
+    y0 = y0
+    args = jnp.linspace(0, 1, n)
+    solver = diffrax.ReversibleHeun()
+    stepsize_controller = diffrax.ConstantStepSize()
+
+    _compare_grads(
+        (y0, args, terms), solver, saveat, stepsize_controller, dual_y0=False
+    )
+
+
+@pytest.mark.parametrize(
+    "saveat",
+    [
+        diffrax.SaveAt(t0=True, t1=True),
+        diffrax.SaveAt(t0=True, ts=jnp.linspace(0, 5, 10), t1=True),
+    ],
+)
+def test_leapfrog_midpoint(saveat):
+    n = 10
+    y0 = jnp.linspace(1, 10, num=n)
+    key = jr.PRNGKey(10)
+    f = VectorField(n, n, n, depth=4, key=key)
+    terms = diffrax.ODETerm(f)
+    y0 = y0
+    args = jnp.linspace(0, 1, n)
+    solver = diffrax.LeapfrogMidpoint()
+    stepsize_controller = diffrax.ConstantStepSize()
+
+    _compare_grads(
+        (y0, args, terms), solver, saveat, stepsize_controller, dual_y0=False
+    )


### PR DESCRIPTION
Implements `AbstractReversibleSolver` base class and `ReversibleAdjoint` for reversible back propagation.

This updates `SemiImplicitEuler`, `LeapfrogMidpoint` and `ReversibleHeun` to subclass `AbstractReversibleSolver`.

### Implementation
`AbstractReversibleSolver` subclasses `AbstractSolver` and adds a `backward_step` method:
```python
@abc.abstractmethod
def backward_step(
    self,
    terms: PyTree[AbstractTerm],
    t0: RealScalarLike,
    t1: RealScalarLike,
    y1: Y,
    args: Args,
    solver_state: _SolverState,
    made_jump: BoolScalarLike,
) -> tuple[Y, DenseInfo, _SolverState]:
```
This method should reconstruct `y0`, `solver_state` at `t0` from `y1`, `solver_state` at `t1`. See the aforementioned solvers for examples.

When backpropagating, `ReversibleAdjoint` uses this `backward_step` to reconstruct state. We then take a `vjp` through a local forward step and accumulate gradients.

`ReversibleAdjoint` now also pulls back gradients from any interpolated values, so we can use `SaveAt(ts=...)`!

We allow arbitrary `solver_state` (provided it can be reconstructed reversibly) and calculate gradients w.r.t. `solver_state`. Finally, we pull back these gradients onto `y0`, `args`, `terms` using the `solver.init` method.



