### PR TITLE
fix for t0==t1 when initializing ys, as opposed to inside the loop

### DIFF
--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -1215,7 +1215,7 @@ def diffeqsolve(
         ts, ys = ts_ys_inf_subsave(out_size)
         if out_size != 0:
             y0_subsave = jtu.tree_map(
-                lambda y: jnp.stack([subsaveat.fn(t0, y, args)] * out_size), y0
+                lambda y: jnp.stack([y] * out_size), subsaveat.fn(t0, y0, args)
             )
             ys = jtu.tree_map(
                 lambda _y0, _ys: jnp.where(t0 == t1, _y0, _ys), y0_subsave, ys


### PR DESCRIPTION
Eliminates code introduced in https://github.com/patrick-kidger/diffrax/pull/494 whereby `ys` was updated inside of the loop to `y0` in the case of `t0==t1`. Now `ys` is instead initialized appropriately with `y0`. This is in response to performance issues observed in https://github.com/patrick-kidger/diffrax/issues/606.