### PR TITLE
start root finder at time of previous ode_solver_step

### DIFF
--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -727,7 +727,7 @@ def loop(
             _event_root_find = optx.root_find(
                 _to_root_find,
                 event.root_finder,
-                y0=final_state.event_tnext,
+                y0=final_state.event_tprev,
                 options=_options,
                 throw=False,
             )


### PR DESCRIPTION
Initialize root finder closer to earlier roots at t_prev instead of t_next, when multiple solutions exist.