### PR TITLE
Use 100 ULP's to clip timesteps close to t1

### DIFF
--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -258,15 +258,11 @@ def _save(
     )
 
 
-def _clip_to_end(tprev, tnext, t1, keep_step):
-    # The tolerance means that we don't end up with too-small intervals for
-    # dense output, which then gives numerically unstable answers due to floating
+def _clip_to_end(tprev, tnext, t1, t1_clip_floor, keep_step):
+    # The tolerance of ~100 ULP's means that we don't end up with too-small intervals
+    # for dense output, which then gives numerically unstable answers due to floating
     # point errors.
-    if tnext.dtype is jnp.dtype("float64"):
-        tol = 1e-10
-    else:
-        tol = 1e-6
-    clip = tnext > t1 - tol
+    clip = tnext > t1_clip_floor
     tclip = jnp.where(keep_step, t1, tprev + 0.5 * (t1 - tprev))
     return jnp.where(clip, tclip, tnext)
 
@@ -303,6 +299,11 @@ def loop(
     outer_while_loop,
     progress_meter,
 ):
+    # Calculate in advance t1 - 100 ULP's: the threshold at which to round tnext to t1
+    t1_clip_floor = t1
+    for _ in range(100):
+        t1_clip_floor = eqxi.prevbefore(t1_clip_floor)
+
     if saveat.dense:
         dense_ts = init_state.dense_ts
         dense_ts = dense_ts.at[0].set(t0)
@@ -392,7 +393,7 @@ def loop(
         #
 
         tprev = jnp.minimum(tprev, t1)
-        tnext = _clip_to_end(tprev, tnext, t1, keep_step)
+        tnext = _clip_to_end(tprev, tnext, t1, t1_clip_floor, keep_step)
 
         progress_meter_state = progress_meter.step(
             state.progress_meter_state, linear_rescale(t0, tprev, t1)

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -303,6 +303,11 @@ def loop(
     t1_clip_floor = t1
     for _ in range(100):
         t1_clip_floor = eqxi.prevbefore(t1_clip_floor)
+    if jnp.sign(t1_clip_floor - t0) != jnp.sign(t1 - t0):
+        raise ValueError(
+            "t0 and t1 are within 100 units of least precision "
+            "implying a high risk of floating point error. Aborting."
+        )
 
     if saveat.dense:
         dense_ts = init_state.dense_ts


### PR DESCRIPTION
This allows timesteps within 100 ULP's of t1 for `ConstantStepSize` which can be smaller than the previously fixed absolute tolerance of `1e-10` for double precision. This fixes #632 and #657 as discussed.

Using `for _ in range(100)` rather than multiplying by `100.0` takes about 7µs rather than 3µs which would be undesirable if we had to perform the computation at every timestep. Fortunately, this is not necessary and we just compute `t1_clip_floor` at the beginning of `_integrate.loop`.

I am ambivalent with whether a multiplier of 100 is optimal here, 1000 would be more than fine for double precision but would limit total number of steps to about 1000 in single precision which seems overly restrictive.

Happy to follow up with a `ConstantStepSize` PR once this is merged.