### PR TITLE
Adding PostProcessSolver Wrapper Class

### DIFF
--- a/diffrax/_solver/base.py
+++ b/diffrax/_solver/base.py
@@ -352,27 +352,7 @@ HalfSolver.__init__.__doc__ = """**Arguments:**
 """
 
 
-class PostProcessSolver(
-    AbstractAdaptiveSolver[_SolverState], AbstractWrappedSolver[_SolverState]
-):
-    """Wraps another solver and postprocesses every step it returns. This lets you
-    tweak the outputs of an existing solver – for example adjusting error estimates,
-    projecting onto constraints, or populating additional dense output fields –
-    without reimplementing the solver itself.
-
-    Each call to `step` runs the wrapped solver once, then forwards the tuple
-    `(y1, y_error, dense_info, solver_state, result)` to `postprocess_fn`. The return
-    value of that function becomes the value returned to the caller, so you can modify
-    or augment any part of the solver's outputs. Aside from whatever work your
-    post-processing does, no extra solver evaluations are required.
-
-    !!! tip
-
-        This is a lightweight way to customise off-the-shelf solvers – use it to add
-        safety checks, change convergence diagnostics, or integrate with external
-        bookkeeping, all while keeping the solver implementation untouched.
-    """
-
+class PostProcessSolver(AbstractWrappedSolver[_SolverState]):
     solver: AbstractSolver[_SolverState]
     postprocess_fn: Callable[
         [Y, Y | None, DenseInfo, _SolverState, RESULTS],
@@ -433,5 +413,4 @@ class PostProcessSolver(
 PostProcessSolver.__init__.__doc__ = """**Arguments:**
 
 - `solver`: The solver to wrap.
-- `postprocess_fn`: Callable applied to every tuple returned by `solver.step`.
 """


### PR DESCRIPTION
I've been using the same kind of trick as suggested in #200  , for a kind of similar reason.

In my case, I'm integrating angular velocities by representing rotations as unit-quaternions (due to: numerical stability, gimbal-lock, ...). For this I had to add a quaternion _renormalization_ which simply divides the quaternion that is returned by the solver by its norm, so that the trajectory "stays" on $\mathrm{SU}(2)$.

As this pattern of _post-processing_ the solvers output seems to be useful in various situations I've opened this PR to propose a simple WrapperClass similar to `HalfStep` that allows to inject some post-processing functionality.

If this feature seems worth adding to diffrax for you, I could also setup an example usecase for unit-testing or maybe also for a small example in the docs.

There might be also some other tricks, that might work with a Wrapper class, such as:

- Ability to extend the `DenseInfo` Struct, so that auxiliary data that is not exposed to `save_fn` can be saved after each step (#650).
- Ability to extend the `SolverState` Struct, so that data from the previous iteration can be passed to the args parameter of the next iteration.


