### PR TITLE
make diffrax compatible with new lineax pre-release

### DIFF
--- a/diffrax/_term.py
+++ b/diffrax/_term.py
@@ -736,7 +736,8 @@ class WrapTerm(AbstractTerm[_VF, _Control]):
     direction: IntScalarLike
 
     def vf(self, t: RealScalarLike, y: Y, args: Args) -> _VF:
-        t = t * self.direction
+        with jax.numpy_dtype_promotion("standard"):
+            t = t * self.direction
         return self.term.vf(t, y, args)
 
     def contr(self, t0: RealScalarLike, t1: RealScalarLike, **kwargs) -> _Control:
@@ -749,7 +750,8 @@ class WrapTerm(AbstractTerm[_VF, _Control]):
             return self.term.prod(vf, control)
 
     def vf_prod(self, t: RealScalarLike, y: Y, args: Args, control: _Control) -> Y:
-        t = t * self.direction
+        with jax.numpy_dtype_promotion("standard"):
+            t = t * self.direction
         return self.term.vf_prod(t, y, args, control)
 
     def is_vf_expensive(

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -631,6 +631,8 @@ def test_term_compatibility():
             return (jax.ShapeDtypeStruct((2, 3), jnp.float64),)
 
     @lx.is_symmetric.register(TestLinearOperator)
+    @lx.is_positive_semidefinite.register(TestLinearOperator)
+    @lx.is_negative_semidefinite.register(TestLinearOperator)
     def _(operator):
         del operator
         return False


### PR DESCRIPTION
Two failures were caused by recent lineax changes

**Failure 1**

Caused by lineax commit [c1fe3b3](https://github.com/patrick-kidger/lineax/commit/c1fe3b3600547e9d438cd256dbf16725f6a4aaee) (Removed AuxLinearOperator) which removed the `_NoAuxOut` wrapper  on `JacobianLinearOperator.out_structure()` which go through `eqxi.cached_filter_eval_shape(fn, self.x)`. But I can't say I really understand this deeply.

**Failure 2**

https://github.com/patrick-kidger/lineax/pull/200 means that `is_symmetric` now consults `is_positive/negatuve_semidefinite` but `TestLinearOperator` never declared this. We could default to returning `False` in lineax, but just adding the registrations to `TestLinearOperator` is the simple option.