### PR TITLE
Fix y_error returned from implicit Euler step when non-linear solve fails

### DIFF
--- a/diffrax/_solver/implicit_euler.py
+++ b/diffrax/_solver/implicit_euler.py
@@ -1,10 +1,10 @@
 from collections.abc import Callable
 from typing import ClassVar, TypeAlias
 
-import optimistix as optx
-from equinox.internal import ω
 import jax.numpy as jnp
 import jax.tree_util as jtu
+import optimistix as optx
+from equinox.internal import ω
 
 from .._custom_types import Args, BoolScalarLike, DenseInfo, RealScalarLike, VF, Y
 from .._heuristics import is_sde

--- a/diffrax/_solver/implicit_euler.py
+++ b/diffrax/_solver/implicit_euler.py
@@ -3,12 +3,14 @@ from typing import ClassVar, TypeAlias
 
 import optimistix as optx
 from equinox.internal import ω
+import jax.numpy as jnp
+import jax.tree_util as jtu
 
 from .._custom_types import Args, BoolScalarLike, DenseInfo, RealScalarLike, VF, Y
 from .._heuristics import is_sde
 from .._local_interpolation import LocalLinearInterpolation
 from .._root_finder import with_stepsize_controller_tols
-from .._solution import RESULTS
+from .._solution import is_okay, RESULTS
 from .._term import AbstractTerm
 from .base import AbstractAdaptiveSolver, AbstractImplicitSolver
 
@@ -94,9 +96,13 @@ class ImplicitEuler(AbstractImplicitSolver, AbstractAdaptiveSolver):
         y1 = (y0**ω + k1**ω).ω
         # Use the trapezoidal rule for adaptive step sizing.
         y_error = (0.5 * (k1**ω - k0**ω)).ω
+        result = RESULTS.promote(nonlinear_sol.result)
+        y_error = jtu.tree_map(
+            lambda _y_error: jnp.where(is_okay(result), _y_error, jnp.inf),
+            y_error,
+        )  # i.e. an implicit step failed to converge
         dense_info = dict(y0=y0, y1=y1)
         solver_state = None
-        result = RESULTS.promote(nonlinear_sol.result)
         return y1, y_error, dense_info, solver_state, result
 
     def func(


### PR DESCRIPTION
As discussed in #752, `ImplicitEuler` solver doesn't check the result returned from the non-linear solver and fails to return an infinite `y_error`, which prevents the stepsize controller from trying a smaller step. This PR fixes this issue by implementing the same logic in the `AbstractRungeKutta`.

If necessary, we could add a test on this logic for all implicit solvers.