### PR TITLE
fix reporting nonconvergence as divergence for non-Cauchy termination

### DIFF
--- a/diffrax/_root_finder/_verychord.py
+++ b/diffrax/_root_finder/_verychord.py
@@ -162,7 +162,7 @@ class VeryChord(optx.AbstractRootFinder):
         converged = _converged(factor, self.kappa)
         terminate = at_least_two & (small | diverged | converged)
         terminate_result = optx.RESULTS.where(
-            at_least_two & jnp.invert(small) & (diverged | jnp.invert(converged)),
+            at_least_two & jnp.invert(small) & diverged,
             optx.RESULTS.nonlinear_divergence,
             optx.RESULTS.successful,
         )

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -50,7 +50,7 @@ def test_implicit_euler_adaptive():
         stepsize_controller=stepsize_controller,
         throw=False,
     )
-    assert out1.result == diffrax.RESULTS.nonlinear_divergence
+    assert out1.result == diffrax.RESULTS.nonlinear_max_steps_reached
     assert out2.result == diffrax.RESULTS.successful
 
 


### PR DESCRIPTION
Fixes https://github.com/patrick-kidger/optimistix/issues/221, also see https://github.com/patrick-kidger/optimistix/pull/230. Note the step counts only reduce from 845 to 242 rather than 238 simply because at_least_two is now doing what it should.

Note that if we manage to progress https://github.com/patrick-kidger/optimistix/pull/214 at some stage (quite an undertaking) we should be able to remove the terminate copy paste issue between VeryChord and AbstractNewtonChord.