### PR TITLE
Allocate the `SaveAt` buffer from the saved value, not its shape

### DIFF
--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -1294,10 +1294,21 @@ def diffeqsolve(
         saveat_ts_index = 0
         save_index = 0
         ts = jnp.full(out_size, direction * jnp.inf, dtype=time_dtype)
-        struct = eqx.filter_eval_shape(subsaveat.fn, t0, y0, args)
-        ys = jtu.tree_map(
-            lambda y: jnp.full((out_size,) + y.shape, jnp.inf, dtype=y.dtype), struct
-        )
+
+        # Allocate the buffer *via* an operation on the saved value, not from its
+        # shape: `jnp.full` conjures an array with no operand, so an array-ish
+        # abstraction wrapping `y0` (a `quax.Value`) is erased as soon as a saved
+        # value round-trips through it (`_save` slices it opposite `y` in a `cond`).
+        # The select's predicate is a compile-time constant, so XLA folds it away
+        # and DCEs the `subsaveat.fn` call feeding the dead branch. `stop_gradient`
+        # is required: without it the buffer gains a tangent path back to `y0` and
+        # `BacksolveAdjoint` trips its `nondifferentiable` guard.
+        def _alloc(y):
+            shape = (out_size,) + jnp.shape(y)
+            fill = jnp.full(shape, jnp.inf, dtype=jnp.result_type(y))
+            return jnp.where(True, fill, lax.stop_gradient(jnp.broadcast_to(y, shape)))
+
+        ys = jtu.tree_map(_alloc, subsaveat.fn(t0, y0, args))
         return SaveState(
             ts=ts, ys=ys, save_index=save_index, saveat_ts_index=saveat_ts_index
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ tests = [
   "jaxlib",
   "optax",
   "pytest",
+  "quax",
   "scipy",
   "tqdm"
 ]

--- a/test/test_quax.py
+++ b/test/test_quax.py
@@ -1,0 +1,89 @@
+"""`diffeqsolve` under `quax.quaxify`.
+
+Quax dispatches on *operations*. An array conjured from a shape rather than
+from an operand -- `jnp.full(shape, ...)` -- gives it nothing to dispatch on,
+so a wrapped `y0` is silently erased the moment a saved value round-trips
+through the `SaveAt` buffer. These tests pin the buffer as an operation on
+the value being saved.
+"""
+
+from collections.abc import Sequence
+
+import diffrax
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+from jax.core import ShapedArray
+from jax.extend.core import Primitive
+
+
+# `quaxify(diffeqsolve)` additionally needs quax's `custom_vjp` support, which
+# diffrax's buffered loops go through; that landed in quax 0.5.0.
+quax = pytest.importorskip("quax", minversion="0.5.0")
+
+
+class Boxed(quax.ArrayValue):
+    """Propagates itself through any primitive it is an operand of.
+
+    Boxes *inexact* outputs only. Boxing integers too would put the box on the
+    solver's own loop counters and save indices, at which point essentially
+    every primitive has a boxed operand and the buffer gets re-boxed on its
+    first write -- which hides exactly the bug under test (and is why
+    `sol.ts` came back wrapped in diffrax#438).
+    """
+
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def aval(self) -> ShapedArray:
+        return ShapedArray(jnp.shape(self.array), jnp.result_type(self.array))
+
+    def materialise(self) -> jax.Array:
+        return self.array
+
+    @staticmethod
+    def default(primitive: Primitive, values: Sequence, params: dict):
+        raw = [v.array if isinstance(v, Boxed) else v for v in values]
+        out = primitive.bind(*raw, **params)
+
+        def box(x):
+            inexact = eqx.is_array(x) and jnp.issubdtype(x.dtype, jnp.inexact)
+            return Boxed(x) if inexact else x
+
+        return [box(x) for x in out] if primitive.multiple_results else box(out)
+
+
+def _solve(y0, saveat):
+    return diffrax.diffeqsolve(
+        diffrax.ODETerm(lambda t, y, args: -0.5 * y),
+        diffrax.Euler(),
+        t0=0.0,
+        t1=1.0,
+        dt0=0.1,
+        y0=y0,
+        saveat=saveat,
+        # `throw=True` erases the type again via equinox's `error_if`:
+        # patrick-kidger/equinox#1257. Not a diffrax issue.
+        throw=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "saveat",
+    [
+        diffrax.SaveAt(t1=True),
+        diffrax.SaveAt(t0=True, t1=True),
+        diffrax.SaveAt(ts=[0.0, 0.5, 1.0]),
+        diffrax.SaveAt(steps=True),
+    ],
+    ids=["t1", "t0t1", "ts", "steps"],
+)
+def test_saveat_buffer_preserves_quax_type(saveat):
+    y0 = jnp.array([1.0])
+    expected = _solve(y0, saveat).ys
+    assert expected is not None
+
+    got = quax.quaxify(_solve)(Boxed(y0), saveat).ys
+
+    assert isinstance(got, Boxed), f"`sol.ys` came back as {type(got).__name__}"
+    assert jnp.array_equal(got.array, expected, equal_nan=True)


### PR DESCRIPTION
Allocates the `SaveAt` output buffer *via* an operation on the value being saved, rather than conjuring it from that value's shape and dtype.

### The problem

`_allocate_output` builds the buffer with `jnp.full`:

```python
struct = eqx.filter_eval_shape(subsaveat.fn, t0, y0, args)
ys = jtu.tree_map(lambda y: jnp.full((out_size,) + y.shape, jnp.inf, dtype=y.dtype), struct)
```

`jnp.full` takes no operand. So when `y0` is an array-ish abstraction — a `quax.Value` carrying units, an uncertainty, a sparsity pattern — there is nothing here for Quax to dispatch on, and the buffer comes out as a plain array. `_save` then puts a slice of that plain buffer opposite the carried value in a `lax.cond`:

```python
y_to_save = lax.cond(
    pred,
    lambda: fn(t, y, args),                                  # the wrapped value
    lambda: jtu.tree_map(lambda ys_: ys_[save_index], ys),   # a plain buffer slice
)
```

The two branches disagree on structure, `cond_p` needs one, and the wrapper is dropped. `sol.ys` comes back as a bare array; a type that declines to materialise (units, say — a dimensionless metre has no meaning) raises instead.

### Why this one can't be fixed from outside

In #438 the conclusion was that Quax shouldn't require changing Diffrax, and for essentially all of `diffeqsolve` that holds — Quax intercepts primitives, and Diffrax is written in primitives. This site is the exception, and structurally so: a rule can only fire where there is an operand to dispatch on, and an array conjured from a shape has none. No set of Quax rules can reach it.

(The workaround in #438 — a `default` rule permissive enough to re-box *everything* — only appears to work because it also boxes the solver's integer loop counters, at which point almost every primitive has a boxed operand and the buffer gets re-boxed on first write. That is also why `sol.ts` came back wrapped there.)

### The change

Keep the `inf` fill exactly, but route it through a `select` whose predicate is a compile-time constant, so `y` is an operand:

```python
y_init = subsaveat.fn(t0, y0, args)
ys = jtu.tree_map(
    lambda y: jnp.where(
        True,
        jnp.full((out_size,) + jnp.shape(y), jnp.inf, dtype=jnp.result_type(y)),
        lax.stop_gradient(jnp.broadcast_to(y, (out_size,) + jnp.shape(y))),
    ),
    y_init,
)
```

XLA folds the select away and DCEs the dead branch — including the `subsaveat.fn` call feeding it.

The `stop_gradient` is load-bearing. Without it the buffer acquires a tangent path back to `y0` — zero-valued, but structurally present — and `BacksolveAdjoint` trips its own `nondifferentiable` guard: `RuntimeError: Unexpected tangent`. That showed up as 4 failures in `test_adjoint.py`. With `stop_gradient` all adjoints produce gradients identical to `main`.

### Cost

XLA cost analysis, 64-dim state, `Tsit5` + `PIDController(rtol=1e-6, atol=1e-8)`, `max_steps=4096`:

| `SaveAt` | flops before → after | bytes accessed | temp memory |
|---|---|---|---|
| `t1=True` | 3,267 → 3,263 | 14,113 → 14,113 | 3,392 → 3,392 |
| `steps=True` | 3,440 → 3,436 | 1,080,575 → 1,080,575 | 1,065,888 → 1,065,888 |
| `steps=True, fn=sin(y)**3+cos(y)` | 3,632 → 3,628 | 1,080,575 → 1,080,575 | 1,065,888 → 1,065,888 |

Four fewer flops, identical memory traffic. The non-trivial `fn` row is there to show the extra `subsaveat.fn` call costs nothing once the dead branch is eliminated.

### Behaviour

Unchanged. Saved values are bit-identical and unwritten slots still read back as `inf` — including `test_saveat_solution.py`'s explicit `jnp.allclose(ys1, jnp.array([0.25, 0.09375, jnp.inf]))`.

One caveat worth naming: `subsaveat.fn` is now invoked once during allocation. It was already invoked inside the solve, so this introduces no new *kind* of behaviour, but a `fn` with a side effect (a `jax.debug.print`, say) would fire one additional time, since DCE removes the pure computation but not the effect.

Two simpler forms that I tried and discarded, in case they come to mind on review:

- `jnp.broadcast_to(y_init, ...)` with no select at all. Changes the fill from `inf` to `y0`, which contradicts the assertions above, and separately broke `test_adjoint.py::test_against`.
- The select without the `stop_gradient`, which breaks `BacksolveAdjoint` as described.

### Test

`test/test_quax.py` asserts `sol.ys` keeps its wrapper across `t1` / `t0,t1` / `ts` / `steps`, that `sol.ts` does *not* pick one up, and that the `inf` fill survives. Verified against this branch: 4 failures before the change, all green after.

It is gated on `quax>=0.5.0` and so currently skips — `quaxify(diffeqsolve)` also needs Quax's `custom_vjp` support (Diffrax's buffered loops route through `jax.custom_vjp`), which lands in that release. Happy to drop the test and the test-group dependency if you would rather not carry a skipped test until then.

### Not fixed here

With the default `throw=True`, the `Solution` is passed through `equinox.internal.error_if`, which allocates its error branch from `jax.eval_shape` + `pure_callback` — the same shape-not-operand pattern, one library over. That erases the type again, so the test uses `throw=False`. Filed as patrick-kidger/equinox#1257, with a candidate patch.
